### PR TITLE
Token is generated from cognito config

### DIFF
--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -17,7 +17,7 @@ open class AuthManager: ObservableObject {
     @Published public var errorMessage: String? = nil
 
     private let authService: AuthServiceProtocol
-    private var tokenProtocol: TokenProtocol?
+    private var tokenProtocol: TokenManagerProtocol?
 
     public init(authService: AuthServiceProtocol = AuthService()) {
         self.authService = authService
@@ -148,7 +148,7 @@ open class AuthManager: ObservableObject {
 @available(iOS 13.0, *)
 extension AuthManager {
     private func manageToken() {
-        self.authService.getIdToken(completion: { [weak self] tokenResult in
+        self.authService.getTokenId(completion: { [weak self] tokenResult in
             guard let self else { return }
             switch tokenResult {
             case .success(let token):
@@ -160,7 +160,7 @@ extension AuthManager {
         })
     }
 
-    public func setTokenProtocol(_ tokenProtocol: TokenProtocol) {
+    public func setTokenProtocol(_ tokenProtocol: TokenManagerProtocol) {
         self.tokenProtocol = tokenProtocol
     }
 }

--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -94,7 +94,6 @@ open class AuthManager: ObservableObject {
     open func signIn(username: String, password: String) {
         authService.signIn(username: username, password: password) { [weak self] result in
             DispatchQueue.main.async { [weak self] in
-                print("SignIn Result: \(result)")
                 if case .success(let signInResult) = result, signInResult == .signedIn {
                     self?.isLoggedIn = true
                     self?.checkUserState()
@@ -154,7 +153,6 @@ extension AuthManager {
             switch tokenResult {
             case .success(let token):
                 guard let tokenProtocol else { return }
-
                 tokenProtocol.manageTokenId(idToken: token)
             case .failure(let error):
                 self.handleError(error)

--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -153,7 +153,8 @@ extension AuthManager {
             switch tokenResult {
             case .success(let token):
                 guard let tokenProtocol else { return }
-                tokenProtocol.manageToken(idToken: token)
+
+                tokenProtocol.manageTokenId(idToken: token)
             case .failure(let error):
                 self.handleError(error)
             }

--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -94,6 +94,7 @@ open class AuthManager: ObservableObject {
     open func signIn(username: String, password: String) {
         authService.signIn(username: username, password: password) { [weak self] result in
             DispatchQueue.main.async { [weak self] in
+                print("SignIn Result: \(result)")
                 if case .success(let signInResult) = result, signInResult == .signedIn {
                     self?.isLoggedIn = true
                     self?.checkUserState()

--- a/Sources/AuthLibrarySPM/App/Service/AuthService.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthService.swift
@@ -50,7 +50,7 @@ public class AuthService: AuthServiceProtocol {
         completion(.success(AWSMobileClient.default().currentUserState))
     }
 
-    public func getIdToken(completion: @escaping (Result<String, AuthError>) -> Void) {
+    public func getTokenId(completion: @escaping (Result<String, AuthError>) -> Void) {
         AWSMobileClient.default().getTokens { tokens, error in
             if let error = error as? AWSMobileClientError {
                 completion(.failure(.awsError(error)))

--- a/Sources/AuthLibrarySPM/App/Service/AuthServiceProtocol.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthServiceProtocol.swift
@@ -14,5 +14,5 @@ public protocol AuthServiceProtocol {
     func signIn(username: String, password: String, completion: @escaping (Result<SignInState, AuthError>) -> Void)
     func signOut(completion: @escaping (Result<Void, AuthError>) -> Void)
     func checkUserState(completion: @escaping (Result<UserState, AuthError>) -> Void)
-    func getIdToken(completion: @escaping (Result<String, AuthError>) -> Void)
+    func getTokenId(completion: @escaping (Result<String, AuthError>) -> Void)
 }

--- a/Sources/AuthLibrarySPM/App/Service/TokenProtocol.swift
+++ b/Sources/AuthLibrarySPM/App/Service/TokenProtocol.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-public protocol TokenProtocol: AnyObject {
+public protocol TokenManagerProtocol: AnyObject {
     func manageToken(idToken: String)
 }

--- a/Sources/AuthLibrarySPM/App/Service/TokenProtocol.swift
+++ b/Sources/AuthLibrarySPM/App/Service/TokenProtocol.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public protocol TokenManagerProtocol: AnyObject {
-    func manageToken(idToken: String)
+    func manageTokenId(idToken: String)
 }

--- a/Sources/AuthLibrarySPM/App/Utils/CredentialStorage.swift
+++ b/Sources/AuthLibrarySPM/App/Utils/CredentialStorage.swift
@@ -8,7 +8,12 @@
 import Foundation
 import KeychainSwift
 
-final public class KeychainManager {
+public protocol KeychainProtocol {
+    func set(_ value: String, key: String)
+    func get(key: String) -> String?
+}
+
+final public class KeychainManager: KeychainProtocol {
     public let keychain: KeychainSwift
     
     public init() {

--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -16,36 +16,37 @@ public struct LoginView: View {
     }
 
     public var body: some View {
-        VStack {
-            Spacer()
-            TextField("Email", text: $viewModel.email)
-                .textFieldStyle()
-                .keyboardType(.emailAddress)
+          VStack {
+              Spacer()
+              TextField("Email", text: $viewModel.email)
+                  .textFieldStyle()
+                  .keyboardType(.emailAddress)
 
-            TextField("Password", text: $viewModel.password)
-                .secureFieldStyle()
+              TextField("Password", text: $viewModel.password)
+                  .secureFieldStyle()
 
-            Button("Login", action: {
-                viewModel.login()
-            })
-            .buttonStyle()
+              Button("Login", action: {
+                  viewModel.login()
+              })
+              .buttonStyle()
 
-            viewModel.authManager.errorTextView
+              viewModel.authManager.errorTextView
 
-            Spacer()
+              Spacer()
 
-            Button("Don't have an account? Sign up.", action: {
-                viewModel.signUp()
-            })
-            .padding(.top, 20)
-        }
-        .padding()
-        .padding(.horizontal, 15)
-        .onAppear {
-            viewModel.clearErrorMessage()
-        }
-    }
-}
+              Button("Don't have an account? Sign up.", action: {
+                  viewModel.signUp()
+              })
+              .padding(.top, 20)
+          }
+          .padding()
+          .padding(.horizontal, 15)
+          .onAppear {
+              viewModel.clearErrorMessage()
+          }
+      }
+  }
+
 
 @available(iOS 14.0, *)
 #Preview {

--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 @available(iOS 14.0, *)
 public struct LoginView: View {
     @StateObject private var viewModel: LoginViewModel
-    @State private var isPasswordVisible: Bool = false
 
     init(viewModel: LoginViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -22,25 +21,9 @@ public struct LoginView: View {
             TextField("Email", text: $viewModel.email)
                 .textFieldStyle()
                 .keyboardType(.emailAddress)
-            ZStack(alignment:  .trailing) {
-                if isPasswordVisible  {
-                    TextField("Password", text: $viewModel.password)
-                        .secureFieldStyle()
-                        .autocapitalization(.none)
-                } else {
-                    SecureField("Password", text: $viewModel.password)
-                        .secureFieldStyle()
-                        .autocapitalization(.none)
-                }
-                Button(action:  {
-                    isPasswordVisible.toggle()
-                }) {
-                    Image(systemName: isPasswordVisible ? "eye.slash.fill" : "eye.fill")
-                        .foregroundColor(.gray)
-                }
-                .padding()
-                .buttonStyle(PlainButtonStyle())
-            }
+
+            TextField("Password", text: $viewModel.password)
+                .secureFieldStyle()
 
             Button("Login", action: {
                 viewModel.login()

--- a/Sources/AuthLibrarySPM/App/ViewModel/LoginViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/LoginViewModel.swift
@@ -13,9 +13,9 @@ public class LoginViewModel: AuthViewModel {
     @Published public var email: String = ""
     @Published public var password: String = ""
 
-    private let keychain: KeychainManager
+    private let keychain: KeychainProtocol
 
-    public init(authManager: AuthManager, keychain: KeychainManager = KeychainManager()) {
+    public init(authManager: AuthManager, keychain: KeychainProtocol = KeychainManager()) {
         self.keychain = keychain
         super.init(authManager: authManager)
         loadCredentials()

--- a/Tests/AuthLibrarySPMTests/AuthManagerTests.swift
+++ b/Tests/AuthLibrarySPMTests/AuthManagerTests.swift
@@ -51,7 +51,7 @@ struct AuthManagerTests {
     func testCheckUserState_NotSignedIn() {
         mockAuthService.checkUserStateResult = .success(.signedOut)
         authManager.checkUserState()
-        
+
         #expect(authManager.isLoggedIn == false)
         #expect(authManager.authState == .login)
     }
@@ -60,11 +60,11 @@ struct AuthManagerTests {
     @Test
     func testSignUp_Success() async throws {
         mockAuthService.signUpResult = .success(.unconfirmed)
-        
+
         authManager.signUp(username: "test@mail.com", password: "password", attributes: [:])
-        
+
         try await Task.sleep(for: .milliseconds(200))
-        
+
         #expect(authManager.authState == .confirmCode(username: "test@mail.com"))
     }
 
@@ -72,7 +72,7 @@ struct AuthManagerTests {
     @Test
     func testSignUp_Failure() async throws {
         mockAuthService.signUpResult = .failure(.unknown)
-        
+
         authManager.signUp(username: "test@mail.com", password: "password", attributes: [:])
         try await Task.sleep(for: .milliseconds(200))
         #expect(authManager.errorMessage != nil)
@@ -81,9 +81,9 @@ struct AuthManagerTests {
     @Test
     func testConfirmSignUp_Success() {
         mockAuthService.confirmSignUpResult = .success(())
-        
+
         authManager.confirmSignUp(username: "test@mail.com", confirmationCode: "123456")
-        
+
         #expect(authManager.authState == .login)
     }
 
@@ -91,10 +91,10 @@ struct AuthManagerTests {
     @Test
     func testConfirmSignUp_Failure() async throws {
         mockAuthService.confirmSignUpResult = .failure(.unknown)
-        
+
         authManager.confirmSignUp(username: "test@mail.com", confirmationCode: "wrongCode")
         try await Task.sleep(for: .milliseconds(200))
-        
+
         #expect(authManager.errorMessage != nil)
     }
 
@@ -105,9 +105,9 @@ struct AuthManagerTests {
         mockAuthService.checkUserStateResult = .success(.signedIn)
 
         authManager.signIn(username: "user@mail.com", password: "password")
-        
+
         try await Task.sleep(for: .milliseconds(200))
-        
+
         #expect(authManager.isLoggedIn == true)
     }
 
@@ -116,19 +116,19 @@ struct AuthManagerTests {
     @Test
     func testSignIn_Failure() async throws {
         mockAuthService.signInResult = .failure(.unknown)
-        
+
         authManager.signIn(username: "user@mail.com", password: "wrongpassword")
         try await Task.sleep(for: .milliseconds(200))
-        
+
         #expect(authManager.errorMessage != nil)
     }
 
     @Test
     func testSignOut_Success() {
         mockAuthService.signOutResult = .success(())
-        
+
         authManager.signOut()
-        
+
         #expect(authManager.isLoggedIn == false)
         #expect(authManager.authState == .login)
     }
@@ -137,10 +137,10 @@ struct AuthManagerTests {
     @Test
     func testSignOut_Failure() async throws {
         mockAuthService.signOutResult = .failure(.unknown)
-        
+
         authManager.signOut()
         try await Task.sleep(for: .milliseconds(200))
-        
+
         #expect(authManager.errorMessage != nil)
     }
 
@@ -148,9 +148,11 @@ struct AuthManagerTests {
     @Test
     func testHandleError_AWSError() async throws {
         let awsError = AWSMobileClientError.unknown(message: "AWS error occurred")
+
         authManager.handleError(.awsError(awsError))
+
         try await Task.sleep(for: .milliseconds(200))
-        
+
         #expect(authManager.errorMessage == awsError.stringMessage)
     }
 
@@ -158,22 +160,28 @@ struct AuthManagerTests {
     @Test
     func testManageToken_Success() async throws {
         let expectedToken = "expectedToken"
+
         mockAuthService.signInResult = .success(.signedIn)
         mockAuthService.getTokenResult = .success(expectedToken)
         authManager.setTokenProtocol(mockTokenHandler)
         authManager.signIn(username: "test", password: "test")
+
         try await Task.sleep(for: .milliseconds(200))
+
         #expect(mockTokenHandler.token == expectedToken)
     }
 
     @available(iOS 16.0, *)
     @Test
     func testManageToken_Failure() async throws {
+
         mockAuthService.signInResult = .success(.signedIn)
         mockAuthService.getTokenResult = .failure(.unknown)
         authManager.setTokenProtocol(mockTokenHandler)
         authManager.signIn(username: "Test", password: "Test")
+
         try await Task.sleep(for: .milliseconds(200))
+
         #expect(mockTokenHandler.token == nil)
 
     }

--- a/Tests/AuthLibrarySPMTests/AuthenticationLibraryTests.swift
+++ b/Tests/AuthLibrarySPMTests/AuthenticationLibraryTests.swift
@@ -108,11 +108,10 @@ struct AuthenticationLibraryTests {
         mockAuthService.signInResult = .success(.signedIn)
         mockAuthService.checkUserStateResult = .success(.signedIn)
         mockAuthService.getTokenResult = .success("Mock-Token")
-
         authManager.setTokenProtocol(mockTokenHandler)
-        authManager.signIn(username: "example@mail.com", password: "password123_")
+        authManager.signIn(username: "testuser@mail.com", password: "password123_")
 
-        try await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(100))
 
         #expect(authManager.isLoggedIn == true)
         #expect(authManager.authState == .session(user: "Session initiated"))
@@ -120,7 +119,7 @@ struct AuthenticationLibraryTests {
     }
 
     @available(iOS 16.0, *)
-    @Test 
+    @Test
     func testSignInFailure() async throws {
         mockAuthService.signInResult = .failure(.awsError(AWSMobileClientError.invalidParameter(message: "Invalid credentials")))
         authManager.signIn(username: "testuser", password: "password")

--- a/Tests/AuthLibrarySPMTests/MockAuthService.swift
+++ b/Tests/AuthLibrarySPMTests/MockAuthService.swift
@@ -11,11 +11,13 @@ import Testing
 import AWSMobileClientXCF
 
 class MockAuthService: AuthServiceProtocol {
+
     var signUpResult: Result<SignUpConfirmationState, AuthError>?
     var confirmSignUpResult: Result<Void, AuthError>? = .success(())
     var signInResult: Result<SignInState, AuthError>?
     var signOutResult: Result<Void, AuthError>? = .success(())
     var checkUserStateResult: Result<UserState, AuthError>?
+    var getTokenResult: Result<String,AuthError>?
 
     func signUp(username: String, password: String, attributes: [String : String], completion: @escaping (Result<SignUpConfirmationState, AuthError>) -> Void) {
         completion(signUpResult ?? .success(.unconfirmed))
@@ -35,5 +37,9 @@ class MockAuthService: AuthServiceProtocol {
 
     func checkUserState(completion: @escaping (Result<UserState, AuthError>) -> Void) {
         completion(checkUserStateResult ?? .success(.signedOut))
+    }
+
+    func getTokenId(completion: @escaping (Result<String, AuthLibrarySPM.AuthError>) -> Void) {
+        completion (getTokenResult ?? .failure(.unknown))
     }
 }

--- a/Tests/AuthLibrarySPMTests/Resources/MockKeychainValues.swift
+++ b/Tests/AuthLibrarySPMTests/Resources/MockKeychainValues.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  AuthLibrarySPM
+//
+//  Created by GenericDevCalifornia on 3/11/25.
+//
+
+import Foundation
+import AuthLibrarySPM
+import KeychainSwift
+
+class MockKeychainValues: KeychainProtocol {
+    public var keychain: [String : Any] = [:]
+
+    func set(_ value: String, key: String) {
+        keychain[key] = value
+    }
+    
+    func get(key: String) -> String? {
+        return keychain[key] as? String
+    }
+}

--- a/Tests/AuthLibrarySPMTests/Resources/MockTokenHandler.swift
+++ b/Tests/AuthLibrarySPMTests/Resources/MockTokenHandler.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  AuthLibrarySPM
+//
+//  Created by GenericDevCalifornia on 3/7/25.
+//
+
+import Foundation
+import AuthLibrarySPM
+
+class MockTokenHandler: TokenManagerProtocol {
+    var token: String?
+
+    func manageTokenId(idToken: String) {
+        self.token = idToken
+    }
+}


### PR DESCRIPTION
# Cognito Token Implementation

The token is now properly generated and temporarily stored in awsconfigfile.json. This allows us to use the secret key to obtain the bearer token and make requests to the Holidays Service in our backend.

To sign in to the app, you must use the same credentials that you use to log in to the company's web page.

https://github.com/user-attachments/assets/000b07e7-a3a5-4a36-8aa2-7fcafa6be1ba

Tests were added for success and failure response 
![Screenshot 2025-03-07 at 4 40 13 PM](https://github.com/user-attachments/assets/09503f0b-840b-4bd7-a17f-2db5acfe92f2)

