### PR TITLE
Extended the Auth App to accept an external LoginView

### DIFF
--- a/Sources/AuthLibrarySPM/App/View/BaseLoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/BaseLoginView.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  AuthLibrarySPM
+//
+//  Created by Trainee on 3/26/25.
+//
+
+import Foundation
+import SwiftUI
+
+@available(iOS 18.0, *)
+public protocol BaseLoginView: View {
+    var viewModel: LoginViewModel {get}
+    
+    func emailTextField() -> AnyView
+    func passwordTextField() -> AnyView
+    func loginButton() -> AnyView
+    func errorMessageLabel() -> AnyView
+    func faceIDToggle() -> AnyView
+    func signUpButton() -> AnyView
+    func clearErrorMessage()
+}

--- a/Sources/AuthLibrarySPM/App/View/BaseLoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/BaseLoginView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 
 @available(iOS 18.0, *)
 public protocol BaseLoginView: View {
-    var viewModel: LoginViewModel {get}
+    var viewModel: LoginViewModel { get }
+    var emailTextField: AnyView { get }
+    var passwordTextField: AnyView { get }
+    var loginButton: AnyView { get }
+    var errorMessageLabel: AnyView { get }
+    var faceIDToggle: AnyView { get }
+    var signUpButton: AnyView { get }
     
-    func emailTextField() -> AnyView
-    func passwordTextField() -> AnyView
-    func loginButton() -> AnyView
-    func errorMessageLabel() -> AnyView
-    func faceIDToggle() -> AnyView
-    func signUpButton() -> AnyView
     func clearErrorMessage()
 }

--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -20,14 +20,14 @@ public struct LoginView: BaseLoginView {
     public var body: some View {
         VStack {
             Spacer()
-            emailTextField()
-            passwordTextField()
-            loginButton()
-            errorMessageLabel()
+            emailTextField
+            passwordTextField
+            loginButton
+            errorMessageLabel
             Spacer().frame(height: 30)
-            faceIDToggle()
+            faceIDToggle
             Spacer()
-            signUpButton()
+            signUpButton
         }
         .padding()
         .padding(.horizontal, 15)
@@ -37,7 +37,7 @@ public struct LoginView: BaseLoginView {
         }
     }
     
-    public func emailTextField() -> AnyView {
+    public var emailTextField: AnyView {
         AnyView (
             TextField("Email", text: $viewModel.email)
                 .textFieldStyle()
@@ -45,7 +45,7 @@ public struct LoginView: BaseLoginView {
         )
     }
     
-    public func passwordTextField() -> AnyView {
+    public var passwordTextField: AnyView {
         AnyView (
             ZStack(alignment:  .trailing) {
                 if isPasswordVisible  {
@@ -69,7 +69,7 @@ public struct LoginView: BaseLoginView {
         )
     }
     
-    public func loginButton() -> AnyView {
+    public var loginButton: AnyView {
         AnyView (
             Button("Login", action: {
                 Task {
@@ -80,13 +80,13 @@ public struct LoginView: BaseLoginView {
         )
     }
     
-    public func errorMessageLabel() -> AnyView {
+    public var errorMessageLabel: AnyView {
         AnyView (
             viewModel.authManager.errorTextView
         )
     }
     
-    public func faceIDToggle() -> AnyView {
+    public var faceIDToggle: AnyView {
         AnyView (
             Toggle(isOn: $viewModel.isFaceIDEnabled) {
                 Image(systemName: "faceid")
@@ -107,7 +107,7 @@ public struct LoginView: BaseLoginView {
         )
     }
     
-    public func signUpButton() -> AnyView {
+    public var signUpButton: AnyView {
         AnyView (
             Button("Don't have an account? Sign up.", action: {
                 viewModel.signUp()

--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -8,21 +8,45 @@
 import SwiftUI
 
 @available(iOS 17.0, *)
-public struct LoginView: View {
-    @StateObject private var viewModel: LoginViewModel
+public struct LoginView: BaseLoginView {
+    
+    @StateObject public var viewModel: LoginViewModel
     @State private var isPasswordVisible: Bool = false
-
-    init(viewModel: LoginViewModel) {
+    
+    public init(viewModel: LoginViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
-
+    
     public var body: some View {
         VStack {
             Spacer()
+            emailTextField()
+            passwordTextField()
+            loginButton()
+            errorMessageLabel()
+            Spacer().frame(height: 30)
+            faceIDToggle()
+            Spacer()
+            signUpButton()
+        }
+        .padding()
+        .padding(.horizontal, 15)
+        .onAppear {
+            clearErrorMessage()
+            Task { await viewModel.tryAutoLogin() }
+        }
+    }
+    
+    public func emailTextField() -> AnyView {
+        AnyView (
             TextField("Email", text: $viewModel.email)
                 .textFieldStyle()
                 .keyboardType(.emailAddress)
-
+        )
+    }
+    
+    public func passwordTextField() -> AnyView {
+        AnyView (
             ZStack(alignment:  .trailing) {
                 if isPasswordVisible  {
                     TextField("Password", text: $viewModel.password)
@@ -42,18 +66,28 @@ public struct LoginView: View {
                 .padding()
                 .buttonStyle(PlainButtonStyle())
             }
-
+        )
+    }
+    
+    public func loginButton() -> AnyView {
+        AnyView (
             Button("Login", action: {
                 Task {
                     await viewModel.login()
                 }
             })
             .buttonStyle()
-
+        )
+    }
+    
+    public func errorMessageLabel() -> AnyView {
+        AnyView (
             viewModel.authManager.errorTextView
-
-            Spacer().frame(height: 30)
-
+        )
+    }
+    
+    public func faceIDToggle() -> AnyView {
+        AnyView (
             Toggle(isOn: $viewModel.isFaceIDEnabled) {
                 Image(systemName: "faceid")
                     .resizable()
@@ -61,29 +95,29 @@ public struct LoginView: View {
                     .frame(width: 30, height: 30)
                     .foregroundColor(viewModel.isFaceIDEnabled ? .blue : .gray)
             }
-            .onChange(of: viewModel.isFaceIDEnabled) { newValue in
-                Task {
-                    await viewModel.toggleFaceID(newValue)
+                .onChange(of: viewModel.isFaceIDEnabled) { newValue in
+                    Task {
+                        await viewModel.toggleFaceID(newValue)
+                    }
                 }
-            }
-            .padding(.horizontal, 100)
-            .frame(maxWidth: .infinity, alignment: .center)
-            .tint(.blue)
-            .scaleEffect(0.8)
-
-            Spacer()
-
+                .padding(.horizontal, 100)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .tint(.blue)
+                .scaleEffect(0.8)
+        )
+    }
+    
+    public func signUpButton() -> AnyView {
+        AnyView (
             Button("Don't have an account? Sign up.", action: {
                 viewModel.signUp()
             })
             .padding(.top, 20)
-        }
-        .padding()
-        .padding(.horizontal, 15)
-        .onAppear {
-            viewModel.clearErrorMessage()
-            Task { await viewModel.tryAutoLogin() }
-        }
+        )
+    }
+    
+    public func clearErrorMessage() {
+        viewModel.clearErrorMessage()
     }
 }
 

--- a/Sources/AuthLibrarySPM/App/ViewModel/LoginViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/LoginViewModel.swift
@@ -45,7 +45,7 @@ public class LoginViewModel: AuthViewModel {
         keychain.set(email, key: "email")
     }
 
-    func tryAutoLogin() async {
+    public func tryAutoLogin() async {
         guard preferences.isAppRelaunch, isFaceIDEnabled else { return }
         preferences.isAppRelaunch = false
         await authenticateAndLogin()

--- a/Sources/AuthLibrarySPM/AuthApp.swift
+++ b/Sources/AuthLibrarySPM/AuthApp.swift
@@ -2,21 +2,26 @@ import AWSMobileClientXCF
 import SwiftUI
 
 @available(iOS 17.0, *)
-public struct AuthApp<SessionViewType: View>: View {
+public struct AuthApp<SessionViewType: View, LoginViewType: View>: View {
     @ObservedObject private var authManager: AuthManager
     @StateObject private var appLifecycleObserver = AppLifecycleObserver()
     private let sessionViewProvider: (String) -> SessionViewType
+    private let loginViewProvider: (LoginViewModel) -> LoginViewType
 
-    public init(authManager: AuthManager, @ViewBuilder sessionView: @escaping (String) -> SessionViewType) {
+    public init(authManager: AuthManager,
+                @ViewBuilder loginView: @escaping (LoginViewModel) -> LoginViewType = { viewModel in  LoginView(viewModel: viewModel)},
+                @ViewBuilder sessionView: @escaping (String) -> SessionViewType) {
         self.authManager = authManager
         self.sessionViewProvider = sessionView
+        self.loginViewProvider = loginView
     }
 
     public var body: some View {
         VStack {
             switch authManager.authState {
             case .login:
-                LoginView(viewModel: LoginViewModel(authManager: authManager, preferences: FaceIDPreferencesManager()))
+                let viewModel = LoginViewModel(authManager: authManager, preferences: FaceIDPreferencesManager())
+                loginViewProvider(viewModel)
             case .signUp:
                 SignUpView(viewModel: SignUpViewModel(authManager: authManager))
             case .confirmCode(let username):


### PR DESCRIPTION
## Summary:
Introduced flexibility to the library's authentication flow by allowing custom login screens to be injected into the AuthApp. 
A protocol-based structure has been implemented to separate authentication logic from UI, enabling developers to customize the UI without modifying the underlying logic.

## Key Changes:

- Added a base protocol `BaseLoginView` to be implemented by custom login views. This protocol defines the required methods for the login screen.
This allows developers to create custom login views while ensuring the underlying authentication logic is preserved.

- The `AuthApp` structure has been updated to support injecting a custom login view.

- The `loginViewProvider` now accepts a `LoginViewModel` and returns a custom `LoginViewType`, enabling flexible customization of the login screen UI.

- A default implementation is provided if no custom `LoginView` is injected, ensuring compatibility.

- The `LoginViewModel` is now passed into the custom `loginViewProvider` during the .`login` state in the `AuthApp`.

- Developers can now define a custom login UI by providing their own implementation of the `LoginView` that conforms to `LoginViewProvider` and is injected into the `AuthApp`.

- The `AuthApp` structure expects two parameters for its initialization:

  - `authManager`: An instance of `AuthManager`, responsible for handling authentication states and actions.

  - `loginView`: A closure that accepts a `LoginViewModel` and returns a custom login view conforming to the `BaseLoginView` protocol. If no custom view is provided, a default `LoginView` is used.

- The `LoginView` has been modified to implement the `BaseLoginView` protocol.

The `AuthApp` renders the login screen based on the `authManager.authState.` When the `authState` is `.login`, it calls the provided `loginViewProvider` to display the login screen.

## Code Example 
 ### With a Custom LoginView
``` Swift
struct AuthAppView: View {

    let authManager = AuthManager()
    let tokenHandler = TokenHandler()
    
    var body: some View {
        AuthApp(authManager: authManager, loginView: { viewModel in CustomLoginScreen(viewModel: viewModel)}) { user in
            TabBarWrapper()
        }
        .environmentObject(authManager)
        .onAppear() {
            resetAuthManager()
            authManager.initializeAWS()
            authManager.checkUserState()
            authManager.setTokenProtocol(tokenHandler)
        }
    }
    
    func resetAuthManager() {
        authManager.authState = .login
        authManager.isLoggedIn = false
        authManager.errorMessage = nil
        authManager.signOut()
    }
}
```

### With the default LoginScreen
```Swift 

struct AuthAppView: View {

    let authManager = AuthManager()
    let tokenHandler = TokenHandler()
    
    var body: some View {
        AuthApp(authManager: authManager) { user in
            TabBarWrapper()
        }
        .environmentObject(authManager)
        .onAppear() {
            resetAuthManager()
            authManager.initializeAWS()
            authManager.checkUserState()
            authManager.setTokenProtocol(tokenHandler)
        }
    }
    
    func resetAuthManager() {
        authManager.authState = .login
        authManager.isLoggedIn = false
        authManager.errorMessage = nil
        authManager.signOut()
    }
}
```
| Custom | Default |
|---------|--------|
| ![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-27 at 16 49 39](https://github.com/user-attachments/assets/bf8a1851-fad0-450b-9351-7519e7f71298) | ![Simulator Screenshot - iPhone 16 Pro Max - 2025-03-27 at 16 51 24](https://github.com/user-attachments/assets/f12c4f54-8cdd-482b-88ec-6bbd2f70fc01) |


