### PR TITLE
Sign up bug fixes

### DIFF
--- a/Sources/AuthLibrarySPM/App/Utils/SecureInputField.swift
+++ b/Sources/AuthLibrarySPM/App/Utils/SecureInputField.swift
@@ -1,0 +1,37 @@
+//
+//  SecureInputField.swift
+//  AuthLibrarySPM
+//
+//  Created by Noel Hiram Pat Angulo on 6/6/25.
+//
+
+import SwiftUI
+
+@available(iOS 13.0, *)
+struct SecureInputField: View {
+    let title: String
+    @Binding var text: String
+    @State private var isNotSecure: Bool = false
+
+    var body: some View {
+        ZStack(alignment:  .trailing) {
+            if isNotSecure  {
+                TextField(title, text: $text)
+                    .secureFieldStyle()
+                    .autocapitalization(.none)
+            } else {
+                SecureField(title, text: $text)
+                    .secureFieldStyle()
+                    .autocapitalization(.none)
+            }
+            Button(action:  {
+                isNotSecure.toggle()
+            }) {
+                Image(systemName: isNotSecure ? "eye.slash.fill" : "eye.fill")
+                    .foregroundColor(.accentColor)
+            }
+            .padding()
+            .buttonStyle(PlainButtonStyle())
+        }
+    }
+}

--- a/Sources/AuthLibrarySPM/App/Utils/StyleHelper.swift
+++ b/Sources/AuthLibrarySPM/App/Utils/StyleHelper.swift
@@ -30,12 +30,17 @@ public struct SecureFieldStyle: ViewModifier {
 
 @available(iOS 13.0, *)
 public struct ButtonStyle: ViewModifier {
+    private var isEnabled : Bool = true
+
+    init(isEnabled : Bool = true){
+        self.isEnabled = isEnabled
+    }
     public func body(content: Content) -> some View {
         content
             .foregroundColor(.white)
             .padding()
             .padding(.horizontal, 40)
-            .background(Color.blue)
+            .background(isEnabled ? Color.blue : Color.gray)
             .cornerRadius(8.0)
             .textContentType(.password)
             .disableAutocorrection(true)
@@ -53,8 +58,8 @@ extension View {
         self.modifier(SecureFieldStyle())
     }
 
-    public func buttonStyle() -> some View {
-        self.modifier(ButtonStyle())
+    public func buttonStyle(isEnabled: Bool = true) -> some View {
+        self.modifier(ButtonStyle(isEnabled: isEnabled))
     }
 }
 

--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -47,25 +47,7 @@ public struct LoginView: BaseLoginView {
     
     public var passwordTextField: AnyView {
         AnyView (
-            ZStack(alignment:  .trailing) {
-                if isPasswordVisible  {
-                    TextField("Password", text: $viewModel.password)
-                        .secureFieldStyle()
-                        .autocapitalization(.none)
-                } else {
-                    SecureField("Password", text: $viewModel.password)
-                        .secureFieldStyle()
-                        .autocapitalization(.none)
-                }
-                Button(action:  {
-                    isPasswordVisible.toggle()
-                }) {
-                    Image(systemName: isPasswordVisible ? "eye.slash.fill" : "eye.fill")
-                        .foregroundColor(.accentColor)
-                }
-                .padding()
-                .buttonStyle(PlainButtonStyle())
-            }
+            SecureInputField(title: "Password", text: $viewModel.password)
         )
     }
     

--- a/Sources/AuthLibrarySPM/App/View/SignUpView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SignUpView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 @available(iOS 14.0, *)
 public struct SignUpView: View {
+    let horizontalPadding : CGFloat = 15
     @StateObject private var viewModel: SignUpViewModel
 
     init(viewModel: SignUpViewModel) {
@@ -20,14 +21,43 @@ public struct SignUpView: View {
             Spacer()
             TextField("Email", text: $viewModel.email)
                 .textFieldStyle()
-            TextField("Password", text: $viewModel.password)
-                .secureFieldStyle()
-            TextField("Confirm Password", text: $viewModel.confirmPassword)
-                .secureFieldStyle()
+                .keyboardType(.emailAddress)
+            SecureInputField(title: "Password", text: $viewModel.password)
+            SecureInputField(
+                title: "Confirm Password",
+                text: $viewModel.confirmPassword
+            )
+
             Button("Sign Up", action: {
                 viewModel.signUp()
             })
-            .buttonStyle()
+            .buttonStyle(isEnabled: viewModel.requirementsFulfilled())
+            .disabled(!viewModel.requirementsFulfilled())
+
+            if let firstRequirement = viewModel.signUpRequirements.first {
+                Text(firstRequirement.text)
+                    .fontWeight(.bold)
+                    .foregroundColor(firstRequirement.isValid() ? .green : .red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Password requirements:")
+                    .fontWeight(.bold)
+
+                ForEach(
+                    viewModel.signUpRequirements.dropFirst(),
+                    id: \.text
+                ) { requirement in
+                    HStack {
+                        Text(requirement.text)
+                            .foregroundColor(
+                                requirement.isValid() ? .green : .red
+                            )
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             viewModel.errorTextView
 
@@ -38,7 +68,7 @@ public struct SignUpView: View {
             })
         }
         .padding()
-        .padding(.horizontal, 15)
+        .padding(.horizontal, horizontalPadding)
         .onAppear {
             viewModel.clearErrorMessage()
         }

--- a/Sources/AuthLibrarySPM/App/ViewModel/SingUpViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/SingUpViewModel.swift
@@ -14,6 +14,32 @@ public class SignUpViewModel: AuthViewModel {
     @Published public var confirmPassword: String = ""
     @Published public var showConfirmationCodeView: Bool = false
 
+    var signUpRequirements: [SignUpRequirements] {
+        [
+            SignUpRequirements(text: "Enter a valid email") {
+                self.email.range(of: #"^\S+@\S+\.\S+$"#, options: .regularExpression) != nil
+            },
+            SignUpRequirements(text: "At least 8 characters") {
+                self.password.count >= 8
+            },
+            SignUpRequirements(text: "At least one uppercase letter") {
+                self.password.range(of: "[A-Z]", options: .regularExpression) != nil
+            },
+            SignUpRequirements(text: "At least one lowercase letter") {
+                self.password.range(of: "[a-z]", options: .regularExpression) != nil
+            },
+            SignUpRequirements(text: "At least one digit") {
+                self.password.range(of: "[0-9]", options: .regularExpression) != nil
+            },
+            SignUpRequirements(text: "At least one special character") {
+                self.password.range(of: "[^A-Za-z0-9]", options: .regularExpression) != nil
+            },
+            SignUpRequirements(text: "Password and confirm password must match") {
+                self.password == self.confirmPassword && !self.confirmPassword.isEmpty
+            }
+        ]
+    }
+
     private let keychain = KeychainManager()
 
     override public init(authManager: AuthManager) {
@@ -29,7 +55,7 @@ public class SignUpViewModel: AuthViewModel {
 
         keychain.set(password, key: CredentialsKeys.password.rawValue)
         keychain.set(email, key: CredentialsKeys.email.rawValue)
-        
+
         let attributes = ["email": email, "name": email]
         authManager.signUp(username: email, password: password, attributes: attributes)
         handleActionResult()
@@ -42,9 +68,18 @@ public class SignUpViewModel: AuthViewModel {
     public override func showLogin() {
         super.showLogin()
     }
+
+    public func requirementsFulfilled() -> Bool {
+        signUpRequirements.allSatisfy { $0.isValid() }
+    }
 }
 
 enum CredentialsKeys: String {
     case email = "email"
     case password = "password"
+}
+
+struct SignUpRequirements {
+    let text: String
+    let isValid: () -> Bool
 }


### PR DESCRIPTION
# Description
This PR fixed the following bugs happening in sign up screen:

- First letter lower case wasn't available for password and confirm password.
- Password and confirm password fields didn't implement secure password input, the text was always visible.
- The email and password were not validated locally and no requirement message was displayed for the users.

# Solution
Added validation for email and password, implemented a view wrapper for secure input and displayed signup requirements for the users.

# Comments
**This library needs to be refactored**

During development of this PR I could observe that this library doesn't implement localizations, it has no dimensions file, views can be split into smaller views, coverage can be increase and unit test needs to be completed.


# Recordings

https://github.com/user-attachments/assets/b5b18a1c-5265-4f5e-be1d-ef8900d46a4a

