### PR TITLE
i18n implemented for en/es

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "AuthLibrarySPM",
+    defaultLocalization: "en",
     platforms: [.iOS(.v12)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -29,7 +30,10 @@ let package = Package(
                             .product(name: "AWSCognitoIdentityProviderASF", package: "aws-sdk-ios-spm"),
                             .product(name: "KeychainSwift", package: "Keychain-swift")
                         ],
-                        path: "Sources"
+                        path: "Sources/AuthLibrarySPM",
+            resources: [
+                .process("Localizations")
+            ]
         ),
         .testTarget(
             name: "AuthLibrarySPMTests",

--- a/Sources/AuthLibrarySPM/App/View/ConfirmationView.swift
+++ b/Sources/AuthLibrarySPM/App/View/ConfirmationView.swift
@@ -17,10 +17,10 @@ public struct ConfirmationView: View {
 
     public var body: some View {
         VStack {
-            Text("Username: \(viewModel.username)")
-            TextField("Confirmation Code", text: $viewModel.confirmationCode)
+            Text(LocalizedStringKeys.UserNameText + viewModel.username)
+            TextField(LocalizedStringKeys.ConfirmationCodeTextField, text: $viewModel.confirmationCode)
                 .textFieldStyle()
-            Button("Confirm", action: {
+            Button(LocalizedStringKeys.ConfirmButtonText, action: {
                 viewModel.confirmSignUp()
             })
             .buttonStyle()
@@ -37,5 +37,5 @@ public struct ConfirmationView: View {
 
 @available(iOS 14.0, *)
 #Preview {
-    ConfirmationView(viewModel: ConfirmationViewModel(authManager: AuthManager(), username: "User"))
+    ConfirmationView(viewModel: ConfirmationViewModel(authManager: AuthManager(), username: LocalizedStringKeys.UserNamePreviewText))
 }

--- a/Sources/AuthLibrarySPM/App/View/ConfirmationView.swift
+++ b/Sources/AuthLibrarySPM/App/View/ConfirmationView.swift
@@ -17,10 +17,10 @@ public struct ConfirmationView: View {
 
     public var body: some View {
         VStack {
-            Text(LocalizedStringKeys.UserNameText + viewModel.username)
-            TextField(LocalizedStringKeys.ConfirmationCodeTextField, text: $viewModel.confirmationCode)
+            Text(LocalizedStringKeys.ConfirmationViewUsernameLabel + viewModel.username)
+            TextField(LocalizedStringKeys.ConfirmationViewCodeTextField, text: $viewModel.confirmationCode)
                 .textFieldStyle()
-            Button(LocalizedStringKeys.ConfirmButtonText, action: {
+            Button(LocalizedStringKeys.ConfirmationViewConfirmButton, action: {
                 viewModel.confirmSignUp()
             })
             .buttonStyle()
@@ -37,5 +37,5 @@ public struct ConfirmationView: View {
 
 @available(iOS 14.0, *)
 #Preview {
-    ConfirmationView(viewModel: ConfirmationViewModel(authManager: AuthManager(), username: LocalizedStringKeys.UserNamePreviewText))
+    ConfirmationView(viewModel: ConfirmationViewModel(authManager: AuthManager(), username: LocalizedStringKeys.ConfirmationViewUsernamePreview))
 }

--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -39,7 +39,7 @@ public struct LoginView: BaseLoginView {
     
     public var emailTextField: AnyView {
         AnyView (
-            TextField(LocalizedStringKeys.EmailTextField, text: $viewModel.email)
+            TextField(LocalizedStringKeys.GeneralEmailTextPlaceHolder, text: $viewModel.email)
                 .textFieldStyle()
                 .keyboardType(.emailAddress)
         )
@@ -47,13 +47,13 @@ public struct LoginView: BaseLoginView {
     
     public var passwordTextField: AnyView {
         AnyView (
-            SecureInputField(title: LocalizedStringKeys.PasswordTextField, text: $viewModel.password)
+            SecureInputField(title: LocalizedStringKeys.GeneralPasswordTexPlaceHolder, text: $viewModel.password)
         )
     }
     
     public var loginButton: AnyView {
         AnyView (
-            Button(LocalizedStringKeys.LoginButtonText, action: {
+            Button(LocalizedStringKeys.GeneralLoginButton, action: {
                 Task {
                     await viewModel.login()
                 }
@@ -71,7 +71,7 @@ public struct LoginView: BaseLoginView {
     public var faceIDToggle: AnyView {
         AnyView (
             Toggle(isOn: $viewModel.isFaceIDEnabled) {
-                Image(systemName: LocalizedStringKeys.ImageSystemName)
+                Image(systemName: LocalizedStringKeys.LoginViewFaceIDImageSystemName)
                     .resizable()
                     .scaledToFit()
                     .frame(width: 30, height: 30)
@@ -91,7 +91,7 @@ public struct LoginView: BaseLoginView {
     
     public var signUpButton: AnyView {
         AnyView (
-            Button(LocalizedStringKeys.SignUpText, action: {
+            Button(LocalizedStringKeys.LoginViewSignUpPrompt, action: {
                 viewModel.signUp()
             })
             .padding(.top, 20)
@@ -107,5 +107,3 @@ public struct LoginView: BaseLoginView {
 #Preview {
     LoginView(viewModel: LoginViewModel(authManager: AuthManager(), preferences: FaceIDPreferencesManager()))
 }
-
-

--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -39,7 +39,7 @@ public struct LoginView: BaseLoginView {
     
     public var emailTextField: AnyView {
         AnyView (
-            TextField("Email", text: $viewModel.email)
+            TextField(LocalizedStringKeys.EmailTextField, text: $viewModel.email)
                 .textFieldStyle()
                 .keyboardType(.emailAddress)
         )
@@ -47,13 +47,13 @@ public struct LoginView: BaseLoginView {
     
     public var passwordTextField: AnyView {
         AnyView (
-            SecureInputField(title: "Password", text: $viewModel.password)
+            SecureInputField(title: LocalizedStringKeys.PasswordTextField, text: $viewModel.password)
         )
     }
     
     public var loginButton: AnyView {
         AnyView (
-            Button("Login", action: {
+            Button(LocalizedStringKeys.LoginButtonText, action: {
                 Task {
                     await viewModel.login()
                 }
@@ -71,7 +71,7 @@ public struct LoginView: BaseLoginView {
     public var faceIDToggle: AnyView {
         AnyView (
             Toggle(isOn: $viewModel.isFaceIDEnabled) {
-                Image(systemName: "faceid")
+                Image(systemName: LocalizedStringKeys.ImageSystemName)
                     .resizable()
                     .scaledToFit()
                     .frame(width: 30, height: 30)
@@ -91,7 +91,7 @@ public struct LoginView: BaseLoginView {
     
     public var signUpButton: AnyView {
         AnyView (
-            Button("Don't have an account? Sign up.", action: {
+            Button(LocalizedStringKeys.SignUpText, action: {
                 viewModel.signUp()
             })
             .padding(.top, 20)
@@ -107,3 +107,5 @@ public struct LoginView: BaseLoginView {
 #Preview {
     LoginView(viewModel: LoginViewModel(authManager: AuthManager(), preferences: FaceIDPreferencesManager()))
 }
+
+

--- a/Sources/AuthLibrarySPM/App/View/SettingsView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SettingsView.swift
@@ -16,9 +16,8 @@ public struct SettingsView: View {
     public var body: some View {
         VStack {
             Spacer()
-            Text("Add more content")
             Spacer()
-            Button("Sign Out", action: authManager.signOut)
+            Button(LocalizedStringKeys.SignOutButtonText, action: authManager.signOut)
                 .buttonStyle()
                 .padding()
             Spacer()

--- a/Sources/AuthLibrarySPM/App/View/SettingsView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SettingsView.swift
@@ -17,7 +17,7 @@ public struct SettingsView: View {
         VStack {
             Spacer()
             Spacer()
-            Button(LocalizedStringKeys.SignOutButtonText, action: authManager.signOut)
+            Button(LocalizedStringKeys.GeneralSignOutButton, action: authManager.signOut)
                 .buttonStyle()
                 .padding()
             Spacer()

--- a/Sources/AuthLibrarySPM/App/View/SignUpView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SignUpView.swift
@@ -19,16 +19,15 @@ public struct SignUpView: View {
     public var body: some View {
         VStack {
             Spacer()
-            TextField(LocalizedStringKeys.EmailTextField, text: $viewModel.email)
+            TextField(LocalizedStringKeys.GeneralEmailTextPlaceHolder, text: $viewModel.email)
                 .textFieldStyle()
                 .keyboardType(.emailAddress)
-            SecureInputField(title: LocalizedStringKeys.PasswordTextField, text: $viewModel.password)
+            SecureInputField(title: LocalizedStringKeys.SignUpViewConfirmPasswordPlaceHolder, text: $viewModel.password)
             SecureInputField(
-                title: LocalizedStringKeys.ConfirmPasswordText,
+                title: LocalizedStringKeys.SignUpViewConfirmPasswordPlaceHolder,
                 text: $viewModel.confirmPassword
             )
-
-            Button(LocalizedStringKeys.SignUpButtonText, action: {
+            Button(LocalizedStringKeys.GeneralSignUpButton, action:{
                 viewModel.signUp()
             })
             .buttonStyle(isEnabled: viewModel.requirementsFulfilled())
@@ -40,11 +39,9 @@ public struct SignUpView: View {
                     .foregroundColor(firstRequirement.isValid() ? .green : .red)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-
             VStack(alignment: .leading, spacing: 4) {
-                Text(LocalizedStringKeys.PasswordRequirementsText)
+                Text(LocalizedStringKeys.SignUpViewPasswordRequirementsLabel.localizedCapitalized)
                     .fontWeight(.bold)
-
                 ForEach(
                     viewModel.signUpRequirements.dropFirst(),
                     id: \.text
@@ -58,12 +55,9 @@ public struct SignUpView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-
             viewModel.errorTextView
-
             Spacer()
-
-            Button(LocalizedStringKeys.AccountExistText, action: {
+            Button(LocalizedStringKeys.SignUpViewAccountExistsPrompt.localizedCapitalized, action: {
                 viewModel.showLogin()
             })
         }
@@ -74,4 +68,3 @@ public struct SignUpView: View {
         }
     }
 }
-

--- a/Sources/AuthLibrarySPM/App/View/SignUpView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SignUpView.swift
@@ -19,16 +19,16 @@ public struct SignUpView: View {
     public var body: some View {
         VStack {
             Spacer()
-            TextField("Email", text: $viewModel.email)
+            TextField(LocalizedStringKeys.EmailTextField, text: $viewModel.email)
                 .textFieldStyle()
                 .keyboardType(.emailAddress)
-            SecureInputField(title: "Password", text: $viewModel.password)
+            SecureInputField(title: LocalizedStringKeys.PasswordTextField, text: $viewModel.password)
             SecureInputField(
-                title: "Confirm Password",
+                title: LocalizedStringKeys.ConfirmPasswordText,
                 text: $viewModel.confirmPassword
             )
 
-            Button("Sign Up", action: {
+            Button(LocalizedStringKeys.SignUpButtonText, action: {
                 viewModel.signUp()
             })
             .buttonStyle(isEnabled: viewModel.requirementsFulfilled())
@@ -42,7 +42,7 @@ public struct SignUpView: View {
             }
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("Password requirements:")
+                Text(LocalizedStringKeys.PasswordRequirementsText)
                     .fontWeight(.bold)
 
                 ForEach(
@@ -63,7 +63,7 @@ public struct SignUpView: View {
 
             Spacer()
 
-            Button("Already have an account? Log in.", action: {
+            Button(LocalizedStringKeys.AccountExistText, action: {
                 viewModel.showLogin()
             })
         }
@@ -74,3 +74,4 @@ public struct SignUpView: View {
         }
     }
 }
+

--- a/Sources/AuthLibrarySPM/App/ViewModel/SingUpViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/SingUpViewModel.swift
@@ -16,25 +16,25 @@ public class SignUpViewModel: AuthViewModel {
 
     var signUpRequirements: [SignUpRequirements] {
         [
-            SignUpRequirements(text: "Enter a valid email") {
+            SignUpRequirements(text: LocalizedStringKeys.EnterValidEmailText) {
                 self.email.range(of: #"^\S+@\S+\.\S+$"#, options: .regularExpression) != nil
             },
-            SignUpRequirements(text: "At least 8 characters") {
+            SignUpRequirements(text: LocalizedStringKeys.EightCharactersText) {
                 self.password.count >= 8
             },
-            SignUpRequirements(text: "At least one uppercase letter") {
+            SignUpRequirements(text: LocalizedStringKeys.OneUppercaseText) {
                 self.password.range(of: "[A-Z]", options: .regularExpression) != nil
             },
-            SignUpRequirements(text: "At least one lowercase letter") {
+            SignUpRequirements(text: LocalizedStringKeys.OneLowercaseText) {
                 self.password.range(of: "[a-z]", options: .regularExpression) != nil
             },
-            SignUpRequirements(text: "At least one digit") {
+            SignUpRequirements(text: LocalizedStringKeys.OneDigitText) {
                 self.password.range(of: "[0-9]", options: .regularExpression) != nil
             },
-            SignUpRequirements(text: "At least one special character") {
+            SignUpRequirements(text: LocalizedStringKeys.OneSpecialCharacter) {
                 self.password.range(of: "[^A-Za-z0-9]", options: .regularExpression) != nil
             },
-            SignUpRequirements(text: "Password and confirm password must match") {
+            SignUpRequirements(text: LocalizedStringKeys.PasswordMismatchText) {
                 self.password == self.confirmPassword && !self.confirmPassword.isEmpty
             }
         ]
@@ -48,7 +48,7 @@ public class SignUpViewModel: AuthViewModel {
 
     public func signUp() {
         guard !email.isEmpty, !password.isEmpty, password == confirmPassword else {
-            self.errorMessage = "Please enter a valid email and matching passwords."
+            self.errorMessage = LocalizedStringKeys.InvalidPasswordEmailText
             handleActionResult()
             return
         }

--- a/Sources/AuthLibrarySPM/App/ViewModel/SingUpViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/SingUpViewModel.swift
@@ -16,25 +16,25 @@ public class SignUpViewModel: AuthViewModel {
 
     var signUpRequirements: [SignUpRequirements] {
         [
-            SignUpRequirements(text: LocalizedStringKeys.EnterValidEmailText) {
+            SignUpRequirements(text: LocalizedStringKeys.SignUpRequirementValidEmail) {
                 self.email.range(of: #"^\S+@\S+\.\S+$"#, options: .regularExpression) != nil
             },
-            SignUpRequirements(text: LocalizedStringKeys.EightCharactersText) {
+            SignUpRequirements(text: LocalizedStringKeys.SignUpRequirementMinLength) {
                 self.password.count >= 8
             },
-            SignUpRequirements(text: LocalizedStringKeys.OneUppercaseText) {
+            SignUpRequirements(text: LocalizedStringKeys.SignUpRequirementUppercase) {
                 self.password.range(of: "[A-Z]", options: .regularExpression) != nil
             },
-            SignUpRequirements(text: LocalizedStringKeys.OneLowercaseText) {
+            SignUpRequirements(text: LocalizedStringKeys.SignUpRequirementLowercase) {
                 self.password.range(of: "[a-z]", options: .regularExpression) != nil
             },
-            SignUpRequirements(text: LocalizedStringKeys.OneDigitText) {
+            SignUpRequirements(text: LocalizedStringKeys.SignUpRequirementDigit) {
                 self.password.range(of: "[0-9]", options: .regularExpression) != nil
             },
-            SignUpRequirements(text: LocalizedStringKeys.OneSpecialCharacter) {
+            SignUpRequirements(text: LocalizedStringKeys.SignUpRequirementSpecialCharacter) {
                 self.password.range(of: "[^A-Za-z0-9]", options: .regularExpression) != nil
             },
-            SignUpRequirements(text: LocalizedStringKeys.PasswordMismatchText) {
+            SignUpRequirements(text: LocalizedStringKeys.SignUpRequirementPasswordMismatch) {
                 self.password == self.confirmPassword && !self.confirmPassword.isEmpty
             }
         ]
@@ -48,7 +48,7 @@ public class SignUpViewModel: AuthViewModel {
 
     public func signUp() {
         guard !email.isEmpty, !password.isEmpty, password == confirmPassword else {
-            self.errorMessage = LocalizedStringKeys.InvalidPasswordEmailText
+            self.errorMessage = LocalizedStringKeys.SignUpRequirementInvalidEmailAndPassword
             handleActionResult()
             return
         }

--- a/Sources/AuthLibrarySPM/Localizations/en.lproj/Localizable.strings
+++ b/Sources/AuthLibrarySPM/Localizations/en.lproj/Localizable.strings
@@ -1,29 +1,27 @@
 // MARK: - General
-"Email_Text_Field" = "Email";
-"Password_Text_Field" = "Password";
-"Login_Button_Text" = "Login";
-"Sign_Up_Button_Text" = "Sign Up";
-"Sign_Out_Button_Text" = "Sign Out";
+"General_EmailTextPlaceHolder" = "Email";
+"General_PasswordTexPlaceHolder" = "Password";
+"General_LoginButton" = "Login";
+"General_SignUpButton" = "Sign Up";
+"General_SignOutButton" = "Sign Out";
 // MARK: - ConfirmationView
-"Username_Text" = "Username: ";
-"Confirmation_Code_Text_Field" = "Confirmation Code";
-"Confirm_Button_Text" = "Confirm";
-"User_Name_Preview_Text" = "User";
+"ConfirmationView_UsernameLabel" = "Username: ";
+"ConfirmationView_CodeTextField" = "Confirmation Code";
+"ConfirmationView_ConfirmButton" = "Confirm";
+"ConfirmationView_UsernamePreview" = "User";
 // MARK: - LoginView
-"Image_System_Name" = "faceid";
-"Sign_Up_Text" = "Don't have an account? Sign up.";
-// MARK: - SessionView
-// MARK: - LoginView
+"LoginView_FaceIDImageSystemName" = "faceid";
+"LoginView_SignUpPrompt" = "Don't have an account? Sign up.";
 // MARK: - SignUpView
-"Confirm_Password_Text" = "Confirm Password";
-"Password_Requirements_Text" = "Password requirements: ";
-"Account_Exist_Text" = "Already have an account? Log in.";
+"SignUpView_ConfirmPasswordPlaceHolder" = "Confirm Password";
+"SignUpView_PasswordRequirementsLabel" = "Password requirements: ";
+"SignUpView_AccountExistsPrompt" = "Already have an account? Log in.";
 // MARK: - SignUpRequirements
-"Enter_Valid_Email_Text" = "Enter a valid email";
-"Eight_Characters_Text" = "At least 8 characters";
-"One_Uppercase_Text" = "At least one uppercase";
-"One_Lowercase_Text" = "At least one lowercase";
-"One_Digit_Text" = "At least one digit";
-"One_Special_Character" = "At least one special character";
-"Password_Mismatch_Text" = "Password and confirm password must match";
-"Invalid_Password_Email_Text" = "Please enter a valid email and matching passwords.";
+"SignUpRequirement_ValidEmail" = "Enter a valid email";
+"SignUpRequirement_MinLength" = "At least 8 characters";
+"SignUpRequirement_Uppercase" = "At least one uppercase";
+"SignUpRequirement_Lowercase" = "At least one lowercase";
+"SignUpRequirement_Digit" = "At least one digit";
+"SignUpRequirement_SpecialCharacter" = "At least one special character";
+"SignUpRequirement_PasswordMismatch" = "Password and confirm password must match";
+"SignUpRequirement_InvalidEmailAndPassword" = "Please enter a valid email and matching passwords.";

--- a/Sources/AuthLibrarySPM/Localizations/en.lproj/Localizable.strings
+++ b/Sources/AuthLibrarySPM/Localizations/en.lproj/Localizable.strings
@@ -1,0 +1,29 @@
+// MARK: - General
+"Email_Text_Field" = "Email";
+"Password_Text_Field" = "Password";
+"Login_Button_Text" = "Login";
+"Sign_Up_Button_Text" = "Sign Up";
+"Sign_Out_Button_Text" = "Sign Out";
+// MARK: - ConfirmationView
+"Username_Text" = "Username: ";
+"Confirmation_Code_Text_Field" = "Confirmation Code";
+"Confirm_Button_Text" = "Confirm";
+"User_Name_Preview_Text" = "User";
+// MARK: - LoginView
+"Image_System_Name" = "faceid";
+"Sign_Up_Text" = "Don't have an account? Sign up.";
+// MARK: - SessionView
+// MARK: - LoginView
+// MARK: - SignUpView
+"Confirm_Password_Text" = "Confirm Password";
+"Password_Requirements_Text" = "Password requirements: ";
+"Account_Exist_Text" = "Already have an account? Log in.";
+// MARK: - SignUpRequirements
+"Enter_Valid_Email_Text" = "Enter a valid email";
+"Eight_Characters_Text" = "At least 8 characters";
+"One_Uppercase_Text" = "At least one uppercase";
+"One_Lowercase_Text" = "At least one lowercase";
+"One_Digit_Text" = "At least one digit";
+"One_Special_Character" = "At least one special character";
+"Password_Mismatch_Text" = "Password and confirm password must match";
+"Invalid_Password_Email_Text" = "Please enter a valid email and matching passwords.";

--- a/Sources/AuthLibrarySPM/Localizations/es.lproj/Localizable.strings
+++ b/Sources/AuthLibrarySPM/Localizations/es.lproj/Localizable.strings
@@ -1,30 +1,27 @@
 // MARK: - General
-"Email_Text_Field" = "Email";
-"Password_Text_Field" = "Password";
-"Login_Button_Text" = "Login";
-"Sign_Up_Button_Text" = "Sign Up";
-"Sign_Out_Button_Text" = "Sign Out";
+"General_EmailTextPlaceHolder" = "Correo electrónico";
+"General_PasswordTexPlaceHolder" = "Contraseña";
+"General_LoginButton" = "Iniciar sesión";
+"General_SignUpButton" = "Registrarse";
+"General_SignOutButton" = "Cerrar sesión";
 // MARK: - ConfirmationView
-"Username_Text" = "Nombre: ";
-"Confirmation_Code_Text_Field" = "Código de confirmación";
-"Confirm_Button_Text" = "Confirmar";
-"User_Name_Preview_Text" = "Usuario";
+"ConfirmationView_UsernameLabel" = "Nombre de usuario: ";
+"ConfirmationView_CodeTextField" = "Código de confirmación";
+"ConfirmationView_ConfirmButton" = "Confirmar";
+"ConfirmationView_UsernamePreview" = "Usuario";
 // MARK: - LoginView
-"Image_System_Name" = "faceid";
-"Sign_Up_Text" = "No tienes cuenta? Sign up.";
-// MARK: - SessionView
-// MARK: - LoginView
+"LoginView_FaceIDImageSystemName" = "faceid";
+"LoginView_SignUpPrompt" = "¿No tienes una cuenta? Regístrate.";
 // MARK: - SignUpView
-"Confirm_Password_Text" = "Confirmar Password";
-"Password_Requirements_Text:" = "Requisitos de Password: ";
-"Account_Exist_Text" = "Ya tienes cuenta? Log in.";
-// MARK: - SignUpRequirments
-"Enter_Valid_Email_Text" = "Ingresa correo válido";
-"Eight_Characters_Text" = "Mínimo 8 carácteres";
-"One_Uppercase_Text" = "Mínimo una mayúscula";
-"One_Lowercase_Text" = "Mínimo una minúscula";
-"One_Digit_Text" = "Mínimo un dígito";
-"One_Special_Character" = "Mínimo un carácter especial";
-"Password_Mismatch_Text" = "Password y confirmación de password deben coincidir";
-"Invalid_Password_Email_Text" = "Por favor ingresa un email y password válidos.";
-
+"SignUpView_ConfirmPasswordPlaceHolder" = "Confirmar contraseña";
+"SignUpView_PasswordRequirementsLabel" = "Requisitos de la contraseña: ";
+"SignUpView_AccountExistsPrompt" = "¿Ya tienes una cuenta? Inicia sesión.";
+// MARK: - SignUpRequirements
+"SignUpRequirement_ValidEmail" = "Ingresa un correo válido";
+"SignUpRequirement_MinLength" = "Al menos 8 caracteres";
+"SignUpRequirement_Uppercase" = "Al menos una mayúscula";
+"SignUpRequirement_Lowercase" = "Al menos una minúscula";
+"SignUpRequirement_Digit" = "Al menos un número";
+"SignUpRequirement_SpecialCharacter" = "Al menos un carácter especial";
+"SignUpRequirement_PasswordMismatch" = "Las contraseñas no coinciden";
+"SignUpRequirement_InvalidEmailAndPassword" = "Ingresa un correo válido y contraseñas que coincidan.";

--- a/Sources/AuthLibrarySPM/Localizations/es.lproj/Localizable.strings
+++ b/Sources/AuthLibrarySPM/Localizations/es.lproj/Localizable.strings
@@ -1,0 +1,30 @@
+// MARK: - General
+"Email_Text_Field" = "Email";
+"Password_Text_Field" = "Password";
+"Login_Button_Text" = "Login";
+"Sign_Up_Button_Text" = "Sign Up";
+"Sign_Out_Button_Text" = "Sign Out";
+// MARK: - ConfirmationView
+"Username_Text" = "Nombre: ";
+"Confirmation_Code_Text_Field" = "Código de confirmación";
+"Confirm_Button_Text" = "Confirmar";
+"User_Name_Preview_Text" = "Usuario";
+// MARK: - LoginView
+"Image_System_Name" = "faceid";
+"Sign_Up_Text" = "No tienes cuenta? Sign up.";
+// MARK: - SessionView
+// MARK: - LoginView
+// MARK: - SignUpView
+"Confirm_Password_Text" = "Confirmar Password";
+"Password_Requirements_Text:" = "Requisitos de Password: ";
+"Account_Exist_Text" = "Ya tienes cuenta? Log in.";
+// MARK: - SignUpRequirments
+"Enter_Valid_Email_Text" = "Ingresa correo válido";
+"Eight_Characters_Text" = "Mínimo 8 carácteres";
+"One_Uppercase_Text" = "Mínimo una mayúscula";
+"One_Lowercase_Text" = "Mínimo una minúscula";
+"One_Digit_Text" = "Mínimo un dígito";
+"One_Special_Character" = "Mínimo un carácter especial";
+"Password_Mismatch_Text" = "Password y confirmación de password deben coincidir";
+"Invalid_Password_Email_Text" = "Por favor ingresa un email y password válidos.";
+

--- a/Sources/AuthLibrarySPM/LocalizedStringKeys.swift
+++ b/Sources/AuthLibrarySPM/LocalizedStringKeys.swift
@@ -6,32 +6,30 @@ public extension String {
 }
 public enum LocalizedStringKeys {
     // MARK: - General
-    public static let EmailTextField = "Email_Text_Field".localized
-    public static let PasswordTextField = "Password_Text_Field".localized
-    public static let SignUpButtonText = "Sign_Up_Button_Text".localized
-    public static let SignOutButtonText = "Sign_Out_Button_Text".localized
+    public static let GeneralEmailTextPlaceHolder = "General_EmailTextPlaceHolder".localized
+    public static let GeneralPasswordTexPlaceHolder = "General_PasswordTexPlaceHolder".localized
+    public static let GeneralLoginButton = "General_LoginButton".localized
+    public static let GeneralSignUpButton = "General_SignUpButton".localized
+    public static let GeneralSignOutButton = "General_SignOutButton".localized
     // MARK: - ConfirmationView
-    public static let UserNameText = "Username_Text".localized
-    public static let ConfirmationCodeTextField = "Confirmation_Code_Text_Field".localized
-    public static let ConfirmButtonText = "Confirm_Button_Text".localized
-    public static let UserNamePreviewText = "User_Name_Preview_Text".localized
+    public static let ConfirmationViewUsernameLabel = "ConfirmationView_UsernameLabel".localized
+    public static let ConfirmationViewCodeTextField = "ConfirmationView_CodeTextField".localized
+    public static let ConfirmationViewConfirmButton = "ConfirmationView_ConfirmButton".localized
+    public static let ConfirmationViewUsernamePreview = "ConfirmationView_UsernamePreview".localized
     // MARK: - LoginView
-    public static let LoginButtonText = "Login_Button_Text".localized
-    public static let ImageSystemName = "Image_System_Name".localized
-    public static let SignUpText = "Sign_Up_Text".localized
-    // MARK: - SessionView
-    // MARK: - SettingsView
+    public static let LoginViewFaceIDImageSystemName = "LoginView_FaceIDImageSystemName".localized
+    public static let LoginViewSignUpPrompt = "LoginView_SignUpPrompt".localized
     // MARK: - SignUpView
-    public static let ConfirmPasswordText = "Confirm_Password_Text".localized
-    public static let PasswordRequirementsText = "Password_Requirements_Text".localized
-    public static let AccountExistText = "Account_Exist_Text".localized
+    public static let SignUpViewConfirmPasswordPlaceHolder = "SignUpView_ConfirmPasswordPlaceHolder".localized
+    public static let SignUpViewPasswordRequirementsLabel = "SignUpView_PasswordRequirementsLabel".localized
+    public static let SignUpViewAccountExistsPrompt = "SignUpView_AccountExistsPrompt".localized
     // MARK: - SignUpRequirements
-    public static let EnterValidEmailText = "Enter_Valid_Email_Text".localized
-    public static let EightCharactersText = "Eight_Characters_Text".localized
-    public static let OneUppercaseText = "One_Uppercase_Text".localized
-    public static let OneLowercaseText = "One_Lowercase_Text".localized
-    public static let OneDigitText = "One_Digit_Text".localized
-    public static let OneSpecialCharacter = "One_Special_Character".localized
-    public static let PasswordMismatchText = "Password_Mismatch_Text".localized
-    public static let InvalidPasswordEmailText = "Invalid_Password_Email_Text".localized
+    public static let SignUpRequirementValidEmail = "SignUpRequirement_ValidEmail".localized
+    public static let SignUpRequirementMinLength = "SignUpRequirement_MinLength".localized
+    public static let SignUpRequirementUppercase = "SignUpRequirement_Uppercase".localized
+    public static let SignUpRequirementLowercase = "SignUpRequirement_Lowercase".localized
+    public static let SignUpRequirementDigit = "SignUpRequirement_Digit".localized
+    public static let SignUpRequirementSpecialCharacter = "SignUpRequirement_SpecialCharacter".localized
+    public static let SignUpRequirementPasswordMismatch = "SignUpRequirement_PasswordMismatch".localized
+    public static let SignUpRequirementInvalidEmailAndPassword = "SignUpRequirement_InvalidEmailAndPassword".localized
 }

--- a/Sources/AuthLibrarySPM/LocalizedStringKeys.swift
+++ b/Sources/AuthLibrarySPM/LocalizedStringKeys.swift
@@ -1,0 +1,37 @@
+import Foundation
+public extension String {
+    public var localized: String {
+        NSLocalizedString(self, bundle: .module, comment: "")
+    }
+}
+public enum LocalizedStringKeys {
+    // MARK: - General
+    public static let EmailTextField = "Email_Text_Field".localized
+    public static let PasswordTextField = "Password_Text_Field".localized
+    public static let SignUpButtonText = "Sign_Up_Button_Text".localized
+    public static let SignOutButtonText = "Sign_Out_Button_Text".localized
+    // MARK: - ConfirmationView
+    public static let UserNameText = "Username_Text".localized
+    public static let ConfirmationCodeTextField = "Confirmation_Code_Text_Field".localized
+    public static let ConfirmButtonText = "Confirm_Button_Text".localized
+    public static let UserNamePreviewText = "User_Name_Preview_Text".localized
+    // MARK: - LoginView
+    public static let LoginButtonText = "Login_Button_Text".localized
+    public static let ImageSystemName = "Image_System_Name".localized
+    public static let SignUpText = "Sign_Up_Text".localized
+    // MARK: - SessionView
+    // MARK: - SettingsView
+    // MARK: - SignUpView
+    public static let ConfirmPasswordText = "Confirm_Password_Text".localized
+    public static let PasswordRequirementsText = "Password_Requirements_Text".localized
+    public static let AccountExistText = "Account_Exist_Text".localized
+    // MARK: - SignUpRequirements
+    public static let EnterValidEmailText = "Enter_Valid_Email_Text".localized
+    public static let EightCharactersText = "Eight_Characters_Text".localized
+    public static let OneUppercaseText = "One_Uppercase_Text".localized
+    public static let OneLowercaseText = "One_Lowercase_Text".localized
+    public static let OneDigitText = "One_Digit_Text".localized
+    public static let OneSpecialCharacter = "One_Special_Character".localized
+    public static let PasswordMismatchText = "Password_Mismatch_Text".localized
+    public static let InvalidPasswordEmailText = "Invalid_Password_Email_Text".localized
+}


### PR DESCRIPTION
### Description
The AuthLibrarySPM package lacked support for internationalization (i18n)

### Solution Implemented
- Structured Localizations using Localizable.strings inside en.lproj and es.lproj
- Bundle resource integration via SwiftPM’s .process("Localizations"), enabling proper .module lookup.
- Added a lightweight LocalizedStringKeys utility and a String.localized extension to simplify localized string usage in SwiftUI views.
- Updated Package.swift to:
        - Set defaultLocalization to "en"
        - Correct resource path alignment relative to AuthLibrarySPM target
- Verified that translations are returned correctly using NSLocalizedString(..., bundle: .module, ...)

### Next Steps / Suggestions

- Add additional .lproj folders for other supported languages
- Expand LocalizedStringKeys for full coverage of UI strings

https://github.com/user-attachments/assets/407a5314-87e3-4f2e-8a4f-52bc6a881d3e

https://github.com/user-attachments/assets/5366fc91-7380-4032-8205-f6ef7e03c7f8



