### PR TITLE
Fixing bugs on check user state

### DIFF
--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -56,13 +56,19 @@ open class AuthManager: ObservableObject {
         }
     }
 
-    open func checkUserState() {
+    open func checkUserState(userName: String = "") {
         handlePublisher(authService.checkUserState()) { [weak self] userState in
             guard let self else { return }
             if case .confirmCode = authStateSubject.value { return }
             isLoggedIn = (userState == .signedIn)
-            authStateSubject.value = isLoggedIn ? .session(user: "Session initiated") : .login
+            authStateSubject.value = isLoggedIn ? .session(user: userName) : .login
             errorSubject.send(nil)
+
+            if isLoggedIn {
+                retrieveIdToken()
+                retrieveRefreshToken()
+                retrieveAccessToken()
+            }
         }
     }
 
@@ -92,7 +98,7 @@ open class AuthManager: ObservableObject {
             guard let self else { return }
             if signInResult == .signedIn {
                 isLoggedIn = true
-                checkUserState()
+                checkUserState(userName: username)
                 retrieveIdToken()
                 retrieveRefreshToken()
                 retrieveAccessToken()


### PR DESCRIPTION
# Description 

An error was causing that even on a recent sign in, an unauthorized message was thrown to the user.

# Solution 

A double validation was added on the auth manager class, to allow to double check the current user state in different lifecycles of the authentication process, also was discovered that the session state wasn't passing the actual user name but a hardcoded string saying "Session initiated" this was replace for the actual userName which allow to unblock an entire feature in the babblebuddy application.

# The error fixed

![bug](https://github.com/user-attachments/assets/b721fdf1-44cd-4564-b715-8108392b0689)
