### PR TITLE
Biometric module and error strings added to LocalizedStringKeys

### DIFF
--- a/Sources/AuthLibrarySPM/App/Biometrics/BiometricsAuthenticator.swift
+++ b/Sources/AuthLibrarySPM/App/Biometrics/BiometricsAuthenticator.swift
@@ -16,19 +16,19 @@ open class FaceIDAuthenticator {
 
     @MainActor
     open func authenticate() async throws -> Bool {
-        context.localizedCancelTitle = "Use Password"
+        context.localizedCancelTitle = LocalizedStringKeys.BiometricAuthenticatorUsePasswordLabel
         
         guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) else {
             throw FaceIdError.biometryNotAvailable
         }
         return try await withCheckedThrowingContinuation { continuation in
-            context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: "Authenticate to access your account") { success, error in
+            context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: LocalizedStringKeys.BiometricAuthenticatorAccessLabel) { success, error in
                 if success {
                     continuation.resume(returning: true)
                 } else if let error = error as? LAError{
                     continuation.resume(throwing: FaceIdError.mapError(error))
                 } else {
-                    continuation.resume(throwing: FaceIdError.authenticationFailed(error?.localizedDescription ?? "unknown error"))
+                    continuation.resume(throwing: FaceIdError.authenticationFailed(error?.localizedDescription ?? LocalizedStringKeys.BiometricAuthenticatorFailedLabel))
                 }
             }
         }
@@ -63,17 +63,17 @@ public enum FaceIdError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .biometryNotAvailable:
-            return "Face ID is not available on this device."
+            return LocalizedStringKeys.BiometricAuthenticatorErrorBiometryNotAvailble
         case .authenticationFailed(let reason):
-            return "Face ID authentication failed: \(reason)"
+            return LocalizedStringKeys.BiometricAuthenticatorErrorAuthenticationFailed + reason
         case .userCanceled:
-            return "Authentication canceled by the user."
+            return LocalizedStringKeys.BiometricAuthenticatorErrorUserCanceled
         case .systemCanceled:
-            return "Authentication was interrupted."
+            return LocalizedStringKeys.BiometricAuthenticatorErrorSystemCanceled
         case .biometryLockout:
-            return "Too many failed attempts. Try again later or use a password."
+            return LocalizedStringKeys.BiometricAuthenticatorErrorBiometryLockout
         case .invalidatedContext:
-            return "Authentication session expired. Try again."
+            return LocalizedStringKeys.BiometricAuthenticatorErrorInvalidatedContext
         }
     }
 }

--- a/Sources/AuthLibrarySPM/Localizations/en.lproj/Localizable.strings
+++ b/Sources/AuthLibrarySPM/Localizations/en.lproj/Localizable.strings
@@ -31,3 +31,14 @@
 "Error_SignupFailed" = "AWSMobileClient initialized with state";
 "Error_UnknownAuthError" = "An unknown error occurred.";
 "Error_TokenExpiredError" = "Token Expired, please, Sign In again.";
+// MARK: - Biometric Authenticator Module
+"BiometricAuthenticator_UsePasswordAccountLabel" = "Use Password";
+"BiometricAuthenticator_AccessAccountLabel" = "Authenticate to access your account";
+"BiometricAuthenticator_FailedLabel" = "Authentication Failed";
+// MARK: - Biometric Authenticator Error Handling
+"BiometricAuthenticatorError_BiometryNotAvailble" = "Face ID is not available on this device.";
+"BiometricAuthenticatorError_AuthenticationFailed" = "Face ID authentication failed: ";
+"BiometricAuthenticatorError_ErrorUserCanceled" = "Authentication canceled by the user.";
+"BiometricAuthenticatorError_ErrorSystemCanceled" = "Authentication was interrupted.";
+"BiometricAuthenticatorError_ErrorBiometryLockout" = "Too many failed attempts. Try again later or use a password.";
+"BiometricAuthenticatorError_ErrorInvalidatedContext" = "Authentication session expired. Try again.";

--- a/Sources/AuthLibrarySPM/Localizations/es.lproj/Localizable.strings
+++ b/Sources/AuthLibrarySPM/Localizations/es.lproj/Localizable.strings
@@ -25,3 +25,20 @@
 "SignUpRequirement_SpecialCharacter" = "Al menos un carácter especial";
 "SignUpRequirement_PasswordMismatch" = "Las contraseñas no coinciden";
 "SignUpRequirement_InvalidEmailAndPassword" = "Ingresa un correo válido y contraseñas que coincidan.";
+//MARK: Error Handling
+"Error_InitializeAWS" = "Error al inicializar AWSMobileClient: ";
+"Error_InitializeAwsState" = "AWSMobileClient inicializado con el estado";
+"Error_SignupFailed" = "AWSMobileClient inicializado con el estado";
+"Error_UnknownAuthError" = "Ocurrió un error desconocido.";
+"Error_TokenExpiredError" = "Token expirado, por favor, inicie sesión nuevamente.";
+// MARK: - Biometric Authenticator Module
+"BiometricAuthenticator_UsePasswordAccountLabel" = "Usar contraseña";
+"BiometricAuthenticator_AccessAccountLabel" = "Autentíquese para acceder a su cuenta";
+"BiometricAuthenticator_FailedLabel" = "Autenticación fallida";
+// MARK: - Biometric Authenticator Error Handling
+"BiometricAuthenticatorError_BiometryNotAvailble" = "Face ID no está disponible en este dispositivo.";
+"BiometricAuthenticatorError_AuthenticationFailed" = "La autenticación con Face ID falló: ";
+"BiometricAuthenticatorError_ErrorUserCanceled" = "Autenticación cancelada por el usuario.";
+"BiometricAuthenticatorError_ErrorSystemCanceled" = "La autenticación fue interrumpida.";
+"BiometricAuthenticatorError_ErrorBiometryLockout" = "Demasiados intentos fallidos. Intente nuevamente más tarde o use una contraseña.";
+"BiometricAuthenticatorError_ErrorInvalidatedContext" = "La sesión de autenticación expiró. Intente nuevamente.";

--- a/Sources/AuthLibrarySPM/LocalizedStringKeys.swift
+++ b/Sources/AuthLibrarySPM/LocalizedStringKeys.swift
@@ -38,4 +38,16 @@ public enum LocalizedStringKeys {
     public static let ErrorSignupFailed = "Error_SignupFailed".localized
     public static let ErrorUnknownAuthError = "Error_UnknownAuthError".localized
     public static let ErrorTokenExpiredError = "Error_TokenExpiredError".localized
+    // MARK: - Biometric Authenticator Module
+    public static let BiometricAuthenticatorUsePasswordLabel = "BiometricAuthenticator_UsePasswordAccountLabel".localized
+    public static let BiometricAuthenticatorAccessLabel = "BiometricAuthenticator_AccessAccountLabel".localized
+    public static let BiometricAuthenticatorFailedLabel = "BiometricAuthenticator_FailedLabel".localized
+    // MARK: - Biometric Authenticator Error Handling
+    public static let BiometricAuthenticatorErrorBiometryNotAvailble = "BiometricAuthenticatorError_BiometryNotAvailble".localized
+    public static let BiometricAuthenticatorErrorAuthenticationFailed = "BiometricAuthenticatorError_AuthenticationFailed".localized
+    public static let BiometricAuthenticatorErrorUserCanceled = "BiometricAuthenticatorError_ErrorUserCanceled".localized
+    public static let BiometricAuthenticatorErrorSystemCanceled = "BiometricAuthenticatorError_ErrorSystemCanceled".localized
+    public static let BiometricAuthenticatorErrorBiometryLockout = "BiometricAuthenticatorError_ErrorBiometryLockout".localized
+    public static let BiometricAuthenticatorErrorInvalidatedContext = "BiometricAuthenticatorError_ErrorInvalidatedContext".localized
+    
 }


### PR DESCRIPTION
### Description:
Refactor the biometric authentication library to replace hardcoded text values with localized string resources, enabling internationalization and better localization support.

• All user-facing text in the biometric library is localized.
• Supported EN and ES.
• No hardcoded strings remain in the biometric module.


https://github.com/user-attachments/assets/c5123c7e-0d16-4617-bcfd-4ad5f9c3867f

https://github.com/user-attachments/assets/ef5255b8-367d-4e51-9677-76957dffc1c7

**How to change to other regions/language**

- In Xcode, open your project settings:
- Click on the blue project file in the navigator
- Select your project (not the target) in the sidebar
- Go to the "Info" tab

**Under "Localizations":**

- Click the "+" button
- Add Spanish (Mexico) (es-MX)
