### PR TITLE
Fixed 401 error due to missing refresh token

### DIFF
--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -22,12 +22,18 @@ open class AuthManager: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
     private var authService: AuthServiceProtocol
-    private var tokenProtocol: TokenManagerProtocol?
+    private var tokenProtocol: TokenManagerProtocol
     private var errorMapper: ErrorMapperProtocol
 
-    public init(authService: AuthServiceProtocol = AuthService(), errorMapper: ErrorMapperProtocol = ErrorMapper()) {
+    public init(
+        authService: AuthServiceProtocol = AuthService(),
+        errorMapper: ErrorMapperProtocol = ErrorMapper(),
+        tokenProtocol: TokenManagerProtocol
+    ) {
         self.authService = authService
         self.errorMapper = errorMapper
+        self.tokenProtocol = tokenProtocol
+        initializeAWS()
         checkUserState()
     }
 
@@ -68,6 +74,11 @@ open class AuthManager: ObservableObject {
                 retrieveIdToken()
                 retrieveRefreshToken()
                 retrieveAccessToken()
+                ensureFreshTokens { success in
+                    if !success {
+                        self.signOut()
+                    }
+                }
             }
         }
     }
@@ -119,10 +130,6 @@ open class AuthManager: ObservableObject {
         self.errorSubject.send(error.errorMessage)
     }
 
-    public func setTokenProtocol(_ tokenProtocol: TokenManagerProtocol) {
-        self.tokenProtocol = tokenProtocol
-    }
-
     open func clearErrorMessage() {
         self.errorSubject.send(nil)
     }
@@ -134,21 +141,21 @@ extension AuthManager {
 
     private func retrieveIdToken() {
         handlePublisher(authService.getTokenId()) { [weak self] token in
-            guard let self, let tokenProtocol else { return }
+            guard let self else { return }
             tokenProtocol.manageTokenId(idToken: token)
         }
     }
 
     private func retrieveRefreshToken() {
         handlePublisher(authService.getRefreshToken()) { [weak self] token in
-            guard let self, let tokenProtocol else { return }
+            guard let self else { return }
             tokenProtocol.manageRefreshToken(refreshToken: token)
         }
     }
 
     private func retrieveAccessToken() {
         handlePublisher(authService.getAccessToken()) { [weak self] token in
-            guard let self, let tokenProtocol else { return }
+            guard let self else { return }
             tokenProtocol.manageAccessToken(accessToken: token)
         }
     }
@@ -163,12 +170,12 @@ extension AuthManager {
                     completion(.failure(.networkError(error)))
                 }
             }, receiveValue: { [weak self] newTokens in
-                guard let self, let tokenProtocol else {
+                guard let self else {
                     completion(.failure(.tokenProtocolUnavailable))
                     return
                 }
 
-                tokenProtocol.clearAllTokens()
+                //                tokenProtocol.clearAllTokens()
                 tokenProtocol.manageTokenId(idToken: newTokens.idToken)
                 tokenProtocol.manageAccessToken(accessToken: newTokens.accessToken)
 
@@ -195,6 +202,29 @@ extension AuthManager {
             }, receiveValue: { success($0) })
             .store(in: &cancellables)
     }
+
+    private func isAccessTokenExpired(_ token: String) -> Bool {
+        let parts = token.split(separator: ".")
+        guard parts.count == 3,
+              let payloadData = Data(base64URLEncoded: String(parts[1])),
+              let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+              let exp = json["exp"] as? TimeInterval
+        else { return true }
+
+        let expiry = Date(timeIntervalSince1970: exp)
+        return expiry.addingTimeInterval(-60) <= Date() // margen 60s
+    }
+
+    public func ensureFreshTokens(completion: @escaping (Bool) -> Void) {
+        if let access = tokenProtocol.getAccessToken(), !isAccessTokenExpired(
+            access
+        ) {
+            completion(true); return
+        }
+        refreshTokensAndStore { result in
+            completion((try? result.get()) != nil)
+        }
+    }
 }
 
 public enum AuthError: Error {
@@ -219,5 +249,16 @@ extension AuthError {
         case .tokenRefreshFailed:
             return LocalizedStringKeys.ErrorTokenExpiredError
         }
+    }
+}
+
+private extension Data {
+    init?(base64URLEncoded: String) {
+        var base = base64URLEncoded
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let pad = 4 - base.count % 4
+        if pad < 4 { base += String(repeating: "=", count: pad) }
+        self.init(base64Encoded: base)
     }
 }

--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -34,7 +34,6 @@ open class AuthManager: ObservableObject {
         self.errorMapper = errorMapper
         self.tokenProtocol = tokenProtocol
         initializeAWS()
-        checkUserState()
     }
 
     open func showSignUp() {
@@ -59,9 +58,9 @@ open class AuthManager: ObservableObject {
 #endif
 
             }
+            self.checkUserState()
         }
     }
-
     open func checkUserState(userName: String = "") {
         handlePublisher(authService.checkUserState()) { [weak self] userState in
             guard let self else { return }
@@ -105,14 +104,29 @@ open class AuthManager: ObservableObject {
     }
 
     open func signIn(username: String, password: String) {
-        handlePublisher(authService.signIn(username: username, password: password)) { [weak self] signInResult in
+        handlePublisher(authService.checkUserState()) { [weak self] current in
             guard let self else { return }
-            if signInResult == .signedIn {
-                isLoggedIn = true
-                checkUserState(userName: username)
-                retrieveIdToken()
-                retrieveRefreshToken()
-                retrieveAccessToken()
+
+            if current == .signedIn {
+                self.isLoggedIn = true
+                self.authStateSubject.send(.session(user: username))
+                self.retrieveIdToken()
+                self.retrieveRefreshToken()
+                self.retrieveAccessToken()
+                self.ensureFreshTokens { _ in }
+                self.errorSubject.send(nil)
+                return
+            }
+
+            self.handlePublisher(self.authService.signIn(username: username, password: password)) { [weak self] result in
+                guard let self else { return }
+                if result == .signedIn {
+                    self.isLoggedIn = true
+                    self.authStateSubject.send(.session(user: username))
+                    self.retrieveIdToken()
+                    self.retrieveRefreshToken()
+                    self.retrieveAccessToken()
+                }
             }
         }
     }
@@ -120,9 +134,10 @@ open class AuthManager: ObservableObject {
     open func signOut() {
         handlePublisher(authService.signOut()) { [weak self] in
             guard let self else { return }
-            isLoggedIn = false
-            checkUserState()
-            errorSubject.send(nil)
+            self.tokenProtocol.clearAllTokens()
+            self.isLoggedIn = false
+            self.authStateSubject.send(.login)
+            self.errorSubject.send(nil)
         }
     }
 

--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -19,12 +19,18 @@ open class AuthManager: ObservableObject {
     public private(set) var errorSubject = PassthroughSubject<String?, Never>()
     public var authStatePublisher: AnyPublisher<AuthState, Never> { authStateSubject.eraseToAnyPublisher() }
     public var errorPublisher: AnyPublisher<String?, Never> { errorSubject.eraseToAnyPublisher() }
+    public private(set) var tokensReadySubject = CurrentValueSubject<Bool, Never>(false)
+    public var tokensReadyPublisher: AnyPublisher<Bool, Never> { tokensReadySubject.eraseToAnyPublisher() }
 
     private var cancellables: Set<AnyCancellable> = []
     private var authService: AuthServiceProtocol
     private var tokenProtocol: TokenManagerProtocol
     private var errorMapper: ErrorMapperProtocol
 
+    private var didInitializeAWS = false
+
+
+    @MainActor
     public init(
         authService: AuthServiceProtocol = AuthService(),
         errorMapper: ErrorMapperProtocol = ErrorMapper(),
@@ -44,23 +50,35 @@ open class AuthManager: ObservableObject {
         authStateSubject.send(.login)
     }
 
-    // TODO: Move to AuthService
+    @MainActor
     open func initializeAWS() {
-        AWSMobileClient.default().initialize { (userState, error) in
-            if let error = error {
-#if DEBUG
-                print(LocalizedStringKeys.ErrorInitializeAWS, error.localizedDescription)
-#endif
-            } else if let userState = userState {
-#if DEBUG
+        guard !didInitializeAWS else { return }
+        didInitializeAWS = true
 
-                print(LocalizedStringKeys.ErrorInitializeAwsState, userState.rawValue)
-#endif
-
+        AWSMobileClient.default().initialize { [weak self] (userState, error) in
+            Task { @MainActor in
+    #if DEBUG
+                if let error { print(LocalizedStringKeys.ErrorInitializeAWS, error.localizedDescription) }
+                if let userState { print(LocalizedStringKeys.ErrorInitializeAwsState, userState.rawValue) }
+    #endif
+                self?.checkUserState()
             }
-            self.checkUserState()
         }
     }
+
+    private func prepareTokensAndNotify() {
+        retrieveIdToken { [weak self] in
+            guard let self else { return }
+            self.retrieveAccessToken { [weak self] in
+                guard let self else { return }
+                self.retrieveRefreshToken()
+                self.ensureFreshTokens { [weak self] _ in
+                    self?.tokensReadySubject.send(true)
+                }
+            }
+        }
+    }
+
     open func checkUserState(userName: String = "") {
         handlePublisher(authService.checkUserState()) { [weak self] userState in
             guard let self else { return }
@@ -70,14 +88,11 @@ open class AuthManager: ObservableObject {
             errorSubject.send(nil)
 
             if isLoggedIn {
-                retrieveIdToken()
-                retrieveRefreshToken()
-                retrieveAccessToken()
-                ensureFreshTokens { success in
-                    if !success {
-                        self.signOut()
-                    }
-                }
+                prepareTokensAndNotify()
+            } else {
+                authStateSubject.value = .login
+                errorSubject.send(nil)
+                tokensReadySubject.send(false)
             }
         }
     }
@@ -110,10 +125,7 @@ open class AuthManager: ObservableObject {
             if current == .signedIn {
                 self.isLoggedIn = true
                 self.authStateSubject.send(.session(user: username))
-                self.retrieveIdToken()
-                self.retrieveRefreshToken()
-                self.retrieveAccessToken()
-                self.ensureFreshTokens { _ in }
+                self.prepareTokensAndNotify()
                 self.errorSubject.send(nil)
                 return
             }
@@ -123,9 +135,7 @@ open class AuthManager: ObservableObject {
                 if result == .signedIn {
                     self.isLoggedIn = true
                     self.authStateSubject.send(.session(user: username))
-                    self.retrieveIdToken()
-                    self.retrieveRefreshToken()
-                    self.retrieveAccessToken()
+                    self.prepareTokensAndNotify()
                 }
             }
         }
@@ -138,6 +148,7 @@ open class AuthManager: ObservableObject {
             self.isLoggedIn = false
             self.authStateSubject.send(.login)
             self.errorSubject.send(nil)
+            self.tokensReadySubject.send(false)
         }
     }
 
@@ -154,10 +165,11 @@ open class AuthManager: ObservableObject {
 @available(iOS 13.0, *)
 extension AuthManager {
 
-    private func retrieveIdToken() {
+    private func retrieveIdToken(completion: (() -> Void)? = nil) {
         handlePublisher(authService.getTokenId()) { [weak self] token in
             guard let self else { return }
             tokenProtocol.manageTokenId(idToken: token)
+            completion?()
         }
     }
 
@@ -168,10 +180,11 @@ extension AuthManager {
         }
     }
 
-    private func retrieveAccessToken() {
+    private func retrieveAccessToken(completion: (() -> Void)? = nil) {
         handlePublisher(authService.getAccessToken()) { [weak self] token in
             guard let self else { return }
             tokenProtocol.manageAccessToken(accessToken: token)
+            completion?()
         }
     }
 
@@ -189,8 +202,6 @@ extension AuthManager {
                     completion(.failure(.tokenProtocolUnavailable))
                     return
                 }
-
-                //                tokenProtocol.clearAllTokens()
                 tokenProtocol.manageTokenId(idToken: newTokens.idToken)
                 tokenProtocol.manageAccessToken(accessToken: newTokens.accessToken)
 
@@ -218,26 +229,35 @@ extension AuthManager {
             .store(in: &cancellables)
     }
 
-    private func isAccessTokenExpired(_ token: String) -> Bool {
+    private func isJWTExpired(_ token: String?) -> Bool {
+        guard let token, !token.isEmpty else { return true }
         let parts = token.split(separator: ".")
         guard parts.count == 3,
               let payloadData = Data(base64URLEncoded: String(parts[1])),
               let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
               let exp = json["exp"] as? TimeInterval
         else { return true }
-
         let expiry = Date(timeIntervalSince1970: exp)
-        return expiry.addingTimeInterval(-60) <= Date() // margen 60s
+        return expiry.addingTimeInterval(-60) <= Date()
     }
 
     public func ensureFreshTokens(completion: @escaping (Bool) -> Void) {
-        if let access = tokenProtocol.getAccessToken(), !isAccessTokenExpired(
-            access
-        ) {
+        let idTok  = tokenProtocol.getIdToken()
+        let accTok = tokenProtocol.getAccessToken()
+
+        if !isJWTExpired(idTok) && !isJWTExpired(accTok) {
             completion(true); return
         }
-        refreshTokensAndStore { result in
-            completion((try? result.get()) != nil)
+
+        refreshTokensAndStore { [weak self] result in
+            switch result {
+            case .success:
+                completion(true)
+            case .failure:
+                 self?.handleError(.tokenRefreshFailed)
+                 self?.signOut()
+                completion(false)
+            }
         }
     }
 }

--- a/Sources/AuthLibrarySPM/App/Service/TokenProtocol.swift
+++ b/Sources/AuthLibrarySPM/App/Service/TokenProtocol.swift
@@ -11,5 +11,6 @@ public protocol TokenManagerProtocol: AnyObject {
     func manageTokenId(idToken: String)
     func manageRefreshToken(refreshToken: String)
     func manageAccessToken(accessToken: String)
+    func getAccessToken() -> String?
     func clearAllTokens()
 }

--- a/Sources/AuthLibrarySPM/App/Service/TokenProtocol.swift
+++ b/Sources/AuthLibrarySPM/App/Service/TokenProtocol.swift
@@ -12,5 +12,6 @@ public protocol TokenManagerProtocol: AnyObject {
     func manageRefreshToken(refreshToken: String)
     func manageAccessToken(accessToken: String)
     func getAccessToken() -> String?
+    func getIdToken() -> String?
     func clearAllTokens()
 }

--- a/Sources/AuthLibrarySPM/App/View/ConfirmationView.swift
+++ b/Sources/AuthLibrarySPM/App/View/ConfirmationView.swift
@@ -35,7 +35,7 @@ public struct ConfirmationView: View {
     }
 }
 
-@available(iOS 14.0, *)
-#Preview {
-    ConfirmationView(viewModel: ConfirmationViewModel(authManager: AuthManager(), username: LocalizedStringKeys.ConfirmationViewUsernamePreview))
-}
+//@available(iOS 14.0, *)
+//#Preview {
+//    ConfirmationView(viewModel: ConfirmationViewModel(authManager: AuthManager(), username: LocalizedStringKeys.ConfirmationViewUsernamePreview))
+//}

--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -103,7 +103,7 @@ public struct LoginView: BaseLoginView {
     }
 }
 
-@available(iOS 17.0, *)
-#Preview {
-    LoginView(viewModel: LoginViewModel(authManager: AuthManager(), preferences: FaceIDPreferencesManager()))
-}
+//@available(iOS 17.0, *)
+//#Preview {
+//    LoginView(viewModel: LoginViewModel(authManager: AuthManager(), preferences: FaceIDPreferencesManager()))
+//}

--- a/Sources/AuthLibrarySPM/App/View/SessionView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SessionView.swift
@@ -46,7 +46,7 @@ public struct SessionView: View {
     }
 }
 
-@available(iOS 14.0, *)
-#Preview {
-    SessionView(viewModel: SessionViewModel(authManager: AuthManager(), user: "user"))
-}
+//@available(iOS 14.0, *)
+//#Preview {
+//    SessionView(viewModel: SessionViewModel(authManager: AuthManager(), user: "user"))
+//}


### PR DESCRIPTION
# Description

This PR attempt to fix the 401 error propagated to the BabbleBuddyiOS app.
Reason was that on the refresh token strategy all tokens were deleted but the refresh token was never updated, empty token was sent and causing the 401 error.
The new added logic first validate the current tokens of the user and if missing or unvalid token is found, the signout is triggered to the user, to log in again.