### PR TITLE
Vladimir/feature/flag to hide biometrics

### DIFF
--- a/Sources/AuthLibrarySPM/App/View/LoginView.swift
+++ b/Sources/AuthLibrarySPM/App/View/LoginView.swift
@@ -25,7 +25,9 @@ public struct LoginView: BaseLoginView {
             loginButton
             errorMessageLabel
             Spacer().frame(height: 30)
-            faceIDToggle
+            if FeatureFlags.shared.isBiometricLoginEnabled{
+                faceIDToggle
+            }
             Spacer()
             signUpButton
         }

--- a/Sources/AuthLibrarySPM/App/View/SettingsView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SettingsView.swift
@@ -12,7 +12,6 @@ public struct SettingsView: View {
     @EnvironmentObject public var authManager: AuthManager
     @State private var isBiometricEnabled: Bool = FeatureFlags.shared.isBiometricLoginEnabled
     
-    
     public init() { }
     
     public var body: some View {

--- a/Sources/AuthLibrarySPM/App/View/SettingsView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SettingsView.swift
@@ -17,6 +17,7 @@ public struct SettingsView: View {
     public var body: some View {
         VStack {
             Spacer()
+#if DEBUG
             Toggle("Biometric Login Feature", isOn: $isBiometricEnabled)
                 .padding()
                 .onChange(of: isBiometricEnabled) { newValue in
@@ -27,12 +28,15 @@ public struct SettingsView: View {
                  : "Biometric Login is disabled")
             .font(.subheadline)
             .padding(.bottom, 8)
+#endif
             Button(LocalizedStringKeys.GeneralSignOutButton, action: authManager.signOut)
                 .buttonStyle()
                 .padding()
             Spacer()
                 .onAppear {
+#if DEBUG
                     isBiometricEnabled = FeatureFlags.shared.isBiometricLoginEnabled
+#endif
                 }
         }
     }

--- a/Sources/AuthLibrarySPM/App/View/SettingsView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SettingsView.swift
@@ -10,17 +10,31 @@ import SwiftUI
 @available(iOS 14.0, *)
 public struct SettingsView: View {
     @EnvironmentObject public var authManager: AuthManager
-
+    @State private var isBiometricEnabled: Bool = FeatureFlags.shared.isBiometricLoginEnabled
+    
+    
     public init() { }
-
+    
     public var body: some View {
         VStack {
             Spacer()
-            Spacer()
+            Toggle("Biometric Login Feature", isOn: $isBiometricEnabled)
+                .padding()
+                .onChange(of: isBiometricEnabled) { newValue in
+                    FeatureFlags.shared.setBiometricEnabled(newValue)
+                }
+            Text(FeatureFlags.shared.isBiometricLoginEnabled
+                 ? "Biometric Login is enabled"
+                 : "Biometric Login is disabled")
+            .font(.subheadline)
+            .padding(.bottom, 8)
             Button(LocalizedStringKeys.GeneralSignOutButton, action: authManager.signOut)
                 .buttonStyle()
                 .padding()
             Spacer()
+                .onAppear {
+                    isBiometricEnabled = FeatureFlags.shared.isBiometricLoginEnabled
+                }
         }
     }
 }

--- a/Sources/AuthLibrarySPM/App/ViewModel/LoginViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/LoginViewModel.swift
@@ -40,10 +40,10 @@ public class LoginViewModel: AuthViewModel {
     public func login() async {
         if !email.isEmpty && !password.isEmpty {
             manualLogin()
-        } else if isFaceIDEnabled {
+        } else if FeatureFlags.shared.isBiometricLoginEnabled && isFaceIDEnabled {
             await authenticateAndLogin()
         } else {
-            errorMessage = "Please enter email and password."
+            errorMessage = LocalizedStringKeys.BiometricAuthenticatorErrorErrorEnterEmailPassword
         }
     }
 
@@ -54,7 +54,7 @@ public class LoginViewModel: AuthViewModel {
     }
 
     public func tryAutoLogin() async {
-        guard preferences.isAppRelaunch, isFaceIDEnabled else { return }
+        guard preferences.isAppRelaunch, FeatureFlags.shared.isBiometricLoginEnabled, isFaceIDEnabled else { return }
         preferences.isAppRelaunch = false
         await authenticateAndLogin()
     }
@@ -67,7 +67,7 @@ public class LoginViewModel: AuthViewModel {
             guard try await faceIDAuthenticator.authenticate() else { return }
 
             guard let credentials = fetchStoredCredentials() else {
-                handleAuthenticationError("No saved credentials found.")
+                handleAuthenticationError(LocalizedStringKeys.BiometricAuthenticatorErrorCredentialsNotFound)
                 return
             }
 
@@ -90,6 +90,10 @@ public class LoginViewModel: AuthViewModel {
     }
 
     public func toggleFaceID(_ enabled: Bool) async {
+        guard FeatureFlags.shared.isBiometricLoginEnabled else {
+                isFaceIDEnabled = false
+                return
+            }
         guard enabled else {
             isFaceIDEnabled = false
             return
@@ -107,7 +111,7 @@ public class LoginViewModel: AuthViewModel {
             errorMessage = error.localizedDescription
             isFaceIDEnabled = false
         } catch {
-            errorMessage = "Face ID permission denied"
+            errorMessage = LocalizedStringKeys.BiometricAuthenticatorErrorFaceIdPermissionDenied
             isFaceIDEnabled = false
         }
     }

--- a/Sources/AuthLibrarySPM/FeatureFlags/FeatureFlags.swift
+++ b/Sources/AuthLibrarySPM/FeatureFlags/FeatureFlags.swift
@@ -1,0 +1,12 @@
+@MainActor
+public class FeatureFlags {
+    public static let shared = FeatureFlags()
+
+    public private(set) var isBiometricLoginEnabled: Bool = false
+
+    public func setBiometricEnabled(_ enabled: Bool) {
+        isBiometricLoginEnabled = enabled
+    }
+
+    private init() {}
+}

--- a/Sources/AuthLibrarySPM/Localizations/en.lproj/Localizable.strings
+++ b/Sources/AuthLibrarySPM/Localizations/en.lproj/Localizable.strings
@@ -42,3 +42,6 @@
 "BiometricAuthenticatorError_ErrorSystemCanceled" = "Authentication was interrupted.";
 "BiometricAuthenticatorError_ErrorBiometryLockout" = "Too many failed attempts. Try again later or use a password.";
 "BiometricAuthenticatorError_ErrorInvalidatedContext" = "Authentication session expired. Try again.";
+"BiometricAuthenticatorError_ErrorEnterEmailPassword" = "Please enter email and password.";
+"BiometricAuthenticatorError_ErrorCredentialsNotFound" = "No saved credentials found.";
+"BiometricAuthenticatorError_ErrorFaceIdPermissionDenied" = "Face ID permission denied.";

--- a/Sources/AuthLibrarySPM/Localizations/es.lproj/Localizable.strings
+++ b/Sources/AuthLibrarySPM/Localizations/es.lproj/Localizable.strings
@@ -42,3 +42,7 @@
 "BiometricAuthenticatorError_ErrorSystemCanceled" = "La autenticación fue interrumpida.";
 "BiometricAuthenticatorError_ErrorBiometryLockout" = "Demasiados intentos fallidos. Intente nuevamente más tarde o use una contraseña.";
 "BiometricAuthenticatorError_ErrorInvalidatedContext" = "La sesión de autenticación expiró. Intente nuevamente.";
+"BiometricAuthenticatorError_ErrorEnterEmailPassword" = "Por favor, introduce el correo electrónico y la contraseña.";
+"BiometricAuthenticatorError_ErrorCredentialsNotFound" = "No se encontraron credenciales guardadas.";
+"BiometricAuthenticatorError_ErrorFaceIdPermissionDenied" = "Permiso de Face ID denegado.";
+

--- a/Sources/AuthLibrarySPM/LocalizedStringKeys.swift
+++ b/Sources/AuthLibrarySPM/LocalizedStringKeys.swift
@@ -49,5 +49,7 @@ public enum LocalizedStringKeys {
     public static let BiometricAuthenticatorErrorSystemCanceled = "BiometricAuthenticatorError_ErrorSystemCanceled".localized
     public static let BiometricAuthenticatorErrorBiometryLockout = "BiometricAuthenticatorError_ErrorBiometryLockout".localized
     public static let BiometricAuthenticatorErrorInvalidatedContext = "BiometricAuthenticatorError_ErrorInvalidatedContext".localized
-    
+    public static let BiometricAuthenticatorErrorErrorEnterEmailPassword = "BiometricAuthenticatorError_ErrorEnterEmailPassword".localized
+    public static let BiometricAuthenticatorErrorCredentialsNotFound = "BiometricAuthenticatorError_ErrorCredentialsNotFound".localized
+    public static let BiometricAuthenticatorErrorFaceIdPermissionDenied = "BiometricAuthenticatorError_ErrorFaceIdPermissionDenied".localized
 }


### PR DESCRIPTION
### Description:
Implement a feature flag to temporarily hide biometric authentication options in BabbleBuddyiO due to ongoing malfunctions. This will prevent users from interacting with unreliable biometric functionality.

- Biometrics are hidden behind a feature flag.
- Flag can be toggled from parent app.
- UI reflects the absence of biometric options when disabled.
- Added if Debug for testing purpose

https://github.com/user-attachments/assets/1edfc78b-e3dd-440b-9ea7-90fb0f2ad268

https://github.com/user-attachments/assets/67ea9b30-43dd-4059-b6bf-91ea5109a6c8


