### PR TITLE
Refactoring library

### DIFF
--- a/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthManager.swift
@@ -10,258 +10,9 @@ import Foundation
 import AWSMobileClientXCF
 import Combine
 import SwiftUI
+import AWSCore
 
-@available(iOS 13.0, *)
-open class AuthManager: ObservableObject {
-    @Published public var isLoggedIn: Bool = false
-
-    public private(set) var authStateSubject = CurrentValueSubject<AuthState, Never>(.login)
-    public private(set) var errorSubject = PassthroughSubject<String?, Never>()
-    public var authStatePublisher: AnyPublisher<AuthState, Never> { authStateSubject.eraseToAnyPublisher() }
-    public var errorPublisher: AnyPublisher<String?, Never> { errorSubject.eraseToAnyPublisher() }
-    public private(set) var tokensReadySubject = CurrentValueSubject<Bool, Never>(false)
-    public var tokensReadyPublisher: AnyPublisher<Bool, Never> { tokensReadySubject.eraseToAnyPublisher() }
-
-    private var cancellables: Set<AnyCancellable> = []
-    private var authService: AuthServiceProtocol
-    private var tokenProtocol: TokenManagerProtocol
-    private var errorMapper: ErrorMapperProtocol
-
-    private var didInitializeAWS = false
-
-
-    @MainActor
-    public init(
-        authService: AuthServiceProtocol = AuthService(),
-        errorMapper: ErrorMapperProtocol = ErrorMapper(),
-        tokenProtocol: TokenManagerProtocol
-    ) {
-        self.authService = authService
-        self.errorMapper = errorMapper
-        self.tokenProtocol = tokenProtocol
-        initializeAWS()
-    }
-
-    open func showSignUp() {
-        authStateSubject.send(.signUp)
-    }
-
-    open func showLogin() {
-        authStateSubject.send(.login)
-    }
-
-    @MainActor
-    open func initializeAWS() {
-        guard !didInitializeAWS else { return }
-        didInitializeAWS = true
-
-        AWSMobileClient.default().initialize { [weak self] (userState, error) in
-            Task { @MainActor in
-    #if DEBUG
-                if let error { print(LocalizedStringKeys.ErrorInitializeAWS, error.localizedDescription) }
-                if let userState { print(LocalizedStringKeys.ErrorInitializeAwsState, userState.rawValue) }
-    #endif
-                self?.checkUserState()
-            }
-        }
-    }
-
-    private func prepareTokensAndNotify() {
-        retrieveIdToken { [weak self] in
-            guard let self else { return }
-            self.retrieveAccessToken { [weak self] in
-                guard let self else { return }
-                self.retrieveRefreshToken()
-                self.ensureFreshTokens { [weak self] _ in
-                    self?.tokensReadySubject.send(true)
-                }
-            }
-        }
-    }
-
-    open func checkUserState(userName: String = "") {
-        handlePublisher(authService.checkUserState()) { [weak self] userState in
-            guard let self else { return }
-            if case .confirmCode = authStateSubject.value { return }
-            isLoggedIn = (userState == .signedIn)
-            authStateSubject.value = isLoggedIn ? .session(user: userName) : .login
-            errorSubject.send(nil)
-
-            if isLoggedIn {
-                prepareTokensAndNotify()
-            } else {
-                authStateSubject.value = .login
-                errorSubject.send(nil)
-                tokensReadySubject.send(false)
-            }
-        }
-    }
-
-    open func signUp(username: String, password: String, attributes: [String: String]) {
-        handlePublisher(authService.signUp(username: username, password: password, attributes: attributes)) { [weak self] signUpResult in
-            guard let self else { return }
-            if signUpResult == .confirmed {
-                errorSubject.send(nil)
-            } else if signUpResult == .unconfirmed {
-                authStateSubject.send(.confirmCode(username: username))
-                errorSubject.send(nil)
-            } else {
-                errorSubject.send(LocalizedStringKeys.ErrorSignupFailed)
-            }
-        }
-    }
-
-    open func confirmSignUp(username: String, confirmationCode: String) {
-        handlePublisher(authService.confirmSignUp(username: username, confirmationCode: confirmationCode)) { [weak self] _ in
-            guard let self else { return }
-            showLogin()
-        }
-    }
-
-    open func signIn(username: String, password: String) {
-        handlePublisher(authService.checkUserState()) { [weak self] current in
-            guard let self else { return }
-
-            if current == .signedIn {
-                self.isLoggedIn = true
-                self.authStateSubject.send(.session(user: username))
-                self.prepareTokensAndNotify()
-                self.errorSubject.send(nil)
-                return
-            }
-
-            self.handlePublisher(self.authService.signIn(username: username, password: password)) { [weak self] result in
-                guard let self else { return }
-                if result == .signedIn {
-                    self.isLoggedIn = true
-                    self.authStateSubject.send(.session(user: username))
-                    self.prepareTokensAndNotify()
-                }
-            }
-        }
-    }
-
-    open func signOut() {
-        handlePublisher(authService.signOut()) { [weak self] in
-            guard let self else { return }
-            self.tokenProtocol.clearAllTokens()
-            self.isLoggedIn = false
-            self.authStateSubject.send(.login)
-            self.errorSubject.send(nil)
-            self.tokensReadySubject.send(false)
-        }
-    }
-
-    open func handleError(_ error: AuthError) {
-        self.errorSubject.send(error.errorMessage)
-    }
-
-    open func clearErrorMessage() {
-        self.errorSubject.send(nil)
-    }
-
-}
-
-@available(iOS 13.0, *)
-extension AuthManager {
-
-    private func retrieveIdToken(completion: (() -> Void)? = nil) {
-        handlePublisher(authService.getTokenId()) { [weak self] token in
-            guard let self else { return }
-            tokenProtocol.manageTokenId(idToken: token)
-            completion?()
-        }
-    }
-
-    private func retrieveRefreshToken() {
-        handlePublisher(authService.getRefreshToken()) { [weak self] token in
-            guard let self else { return }
-            tokenProtocol.manageRefreshToken(refreshToken: token)
-        }
-    }
-
-    private func retrieveAccessToken(completion: (() -> Void)? = nil) {
-        handlePublisher(authService.getAccessToken()) { [weak self] token in
-            guard let self else { return }
-            tokenProtocol.manageAccessToken(accessToken: token)
-            completion?()
-        }
-    }
-
-    public func refreshTokensAndStore(completion: @escaping (Result<Void, RefreshTokenError>) -> Void) {
-        authService.refreshTokens()
-            .sink(receiveCompletion: { completionResult in
-                switch completionResult {
-                case .finished:
-                    break
-                case .failure(let error):
-                    completion(.failure(.networkError(error)))
-                }
-            }, receiveValue: { [weak self] newTokens in
-                guard let self else {
-                    completion(.failure(.tokenProtocolUnavailable))
-                    return
-                }
-                tokenProtocol.manageTokenId(idToken: newTokens.idToken)
-                tokenProtocol.manageAccessToken(accessToken: newTokens.accessToken)
-
-                completion(.success(()))
-            })
-            .store(in: &cancellables)
-    }
-
-
-    private func handlePublisher<T>(_ publisher: AnyPublisher<T, AuthError>, success: @escaping (T) -> Void) {
-        publisher
-            .mapError { error -> AuthError in
-                if case let .awsError(awsError) = error {
-                    return self.errorMapper.map(awsError)
-                }
-                return .unknown
-            }
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { [weak self] completion in
-                guard let self else { return }
-                if case .failure(let error) = completion {
-                    handleError(error)
-                }
-            }, receiveValue: { success($0) })
-            .store(in: &cancellables)
-    }
-
-    private func isJWTExpired(_ token: String?) -> Bool {
-        guard let token, !token.isEmpty else { return true }
-        let parts = token.split(separator: ".")
-        guard parts.count == 3,
-              let payloadData = Data(base64URLEncoded: String(parts[1])),
-              let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
-              let exp = json["exp"] as? TimeInterval
-        else { return true }
-        let expiry = Date(timeIntervalSince1970: exp)
-        return expiry.addingTimeInterval(-60) <= Date()
-    }
-
-    public func ensureFreshTokens(completion: @escaping (Bool) -> Void) {
-        let idTok  = tokenProtocol.getIdToken()
-        let accTok = tokenProtocol.getAccessToken()
-
-        if !isJWTExpired(idTok) && !isJWTExpired(accTok) {
-            completion(true); return
-        }
-
-        refreshTokensAndStore { [weak self] result in
-            switch result {
-            case .success:
-                completion(true)
-            case .failure:
-                 self?.handleError(.tokenRefreshFailed)
-                 self?.signOut()
-                completion(false)
-            }
-        }
-    }
-}
-
+// MARK: - Errors
 public enum AuthError: Error {
     case awsError(AWSMobileClientError)
     case unknown
@@ -277,16 +28,281 @@ public enum RefreshTokenError: Error {
 extension AuthError {
     var errorMessage: String {
         switch self {
-        case .awsError(let error):
-            return error.stringMessage
-        case .unknown:
-            return LocalizedStringKeys.ErrorUnknownAuthError
-        case .tokenRefreshFailed:
-            return LocalizedStringKeys.ErrorTokenExpiredError
+        case .awsError(let e): return e.stringMessage
+        case .unknown:         return "Unknown auth error"
+        case .tokenRefreshFailed: return "Token refresh failed"
         }
     }
 }
 
+public enum UserState { case signedIn, signedOut }
+public enum SignUpResult { case confirmed, unconfirmed }
+public enum SignInResult { case signedIn, nextStep }
+
+@available(iOS 13.0, *)
+@MainActor
+open class AuthManager: ObservableObject {
+
+    // MARK: Public properties
+    @Published public private(set) var isLoggedIn: Bool = false
+    public private(set) var authStateSubject   = CurrentValueSubject<AuthState, Never>(.login)
+    public private(set) var errorSubject       = PassthroughSubject<String?, Never>()
+    public private(set) var tokensReadySubject = CurrentValueSubject<Bool, Never>(false)
+    public var authStatePublisher: AnyPublisher<AuthState, Never> { authStateSubject.eraseToAnyPublisher() }
+    public var errorPublisher: AnyPublisher<String?, Never>       { errorSubject.eraseToAnyPublisher() }
+    public var tokensReadyPublisher: AnyPublisher<Bool, Never>    { tokensReadySubject.eraseToAnyPublisher() }
+
+    // MARK: Private properties
+    private let authService: AuthServiceProtocol
+    private let tokenStore: TokenManagerProtocol
+    private let errorMapper: ErrorMapperProtocol
+    private var cancellables = Set<AnyCancellable>()
+    private var didInitializeAWS = false
+    private let expirySkewSeconds: TimeInterval = 120
+
+    // MARK: - Init
+    public init(
+        authService: AuthServiceProtocol = AuthService(),
+        errorMapper: ErrorMapperProtocol = ErrorMapper(),
+        tokenProtocol: TokenManagerProtocol
+    ) {
+        self.authService = authService
+        self.errorMapper = errorMapper
+        self.tokenStore  = tokenProtocol
+        initializeAWS()
+    }
+
+    // MARK: - Public API
+    open func showSignUp()  { authStateSubject.send(.signUp) }
+    open func showLogin()   { authStateSubject.send(.login)  }
+    open func clearErrorMessage() { errorSubject.send(nil) }
+    open func handleError(_ error: AuthError) {
+        errorSubject.send(error.errorMessage)
+    }
+
+    open func signUp(username: String, password: String, attributes: [String: String]) {
+        handlePublisher(authService.signUp(username: username, password: password, attributes: attributes)) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .confirmed:
+                self.errorSubject.send(nil)
+                self.showLogin()
+            case .unconfirmed:
+                self.authStateSubject.send(.confirmCode(username: username))
+                self.errorSubject.send(nil)
+            case .unknown:
+                break
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    open func confirmSignUp(username: String, confirmationCode: String) {
+        handlePublisher(authService.confirmSignUp(username: username, confirmationCode: confirmationCode)) { [weak self] _ in
+            self?.showLogin()
+        }
+    }
+
+    open func signIn(username: String, password: String) {
+        handlePublisher(authService.checkUserState()) { [weak self] state in
+            guard let self else { return }
+            if state == .signedIn {
+                self.setSignedIn(user: username)
+                self.prepareTokensAndNotify()
+                return
+            }
+
+            self.handlePublisher(self.authService.signIn(username: username, password: password)) { [weak self] r in
+                guard let self else { return }
+                if r == .signedIn {
+                    self.setSignedIn(user: username)
+                    self.prepareTokensAndNotify()
+                } else {
+                    self.handleError(.unknown)
+                }
+            }
+        }
+    }
+
+    open func signOut() {
+        handlePublisher(authService.signOut()) { [weak self] in
+            guard let self else { return }
+            self.tokenStore.clearAllTokens()
+            self.isLoggedIn = false
+            self.authStateSubject.send(.login)
+            self.errorSubject.send(nil)
+            self.tokensReadySubject.send(false)
+        }
+    }
+
+    // MARK: - AWS bootstrap
+    open func initializeAWS() {
+        guard !didInitializeAWS else { return }
+        didInitializeAWS = true
+
+        AWSMobileClient.default().initialize { [weak self] (_, error) in
+            Task { @MainActor in
+                #if DEBUG
+                if let error { print("AWS init error:", error.localizedDescription) }
+                #endif
+                self?.checkUserState()
+            }
+        }
+    }
+
+    open func checkUserState(userName: String = "") {
+        handlePublisher(authService.checkUserState()) { [weak self] state in
+            guard let self else { return }
+
+            if case .confirmCode = self.authStateSubject.value { return }
+
+            let signedIn = (state == .signedIn)
+            self.isLoggedIn = signedIn
+            self.authStateSubject.send(signedIn ? .session(user: userName) : .login)
+            self.errorSubject.send(nil)
+
+            self.tokensReadySubject.send(false)
+
+            if signedIn {
+                self.prepareTokensAndNotify()
+            } else {
+                self.tokensReadySubject.send(false)
+            }
+        }
+    }
+
+    // MARK: - Core: Tokens & readiness
+    private func prepareTokensAndNotify() {
+        if let id = tokenStore.getIdToken(), !id.isEmpty,
+           let ac = tokenStore.getAccessToken(), !ac.isEmpty {
+            tokensReadySubject.send(true)
+            refreshIfNeededInBackground()
+            return
+        }
+
+        retrieveIdThenAccessThenRefresh { [weak self] gotSomething in
+            guard let self else { return }
+            if gotSomething {
+                self.tokensReadySubject.send(true)
+                self.refreshIfNeededInBackground()
+            } else {
+                Task { [weak self] in
+                    guard let self else { return }
+                    let ok = await self.refreshWithRetries(maxRetries: 3, delayMs: 250)
+                    self.tokensReadySubject.send(ok)
+                    if !ok {
+                        self.handleError(.tokenRefreshFailed)
+                    }
+                }
+            }
+        }
+    }
+
+    private func refreshIfNeededInBackground() {
+        let id  = tokenStore.getIdToken()
+        let ac  = tokenStore.getAccessToken()
+        if isJWTExpired(id, skew: expirySkewSeconds) || isJWTExpired(ac, skew: expirySkewSeconds) {
+            Task { [weak self] in
+                guard let self else { return }
+                _ = await self.refreshWithRetries(maxRetries: 2, delayMs: 250)
+            }
+        }
+    }
+
+    private func retrieveIdThenAccessThenRefresh(completion: @escaping (Bool) -> Void) {
+        handlePublisher(authService.getTokenId()) { [weak self] id in
+            guard let self else { completion(false); return }
+            self.tokenStore.manageTokenId(idToken: id)
+
+            self.handlePublisher(self.authService.getAccessToken()) { [weak self] acc in
+                guard let self else { completion(false); return }
+                self.tokenStore.manageAccessToken(accessToken: acc)
+
+                self.handlePublisher(self.authService.getRefreshToken()) { [weak self] ref in
+                    guard let self else { completion(false); return }
+                    self.tokenStore.manageRefreshToken(refreshToken: ref)
+
+                    let hasAll = (self.tokenStore.getIdToken()?.isEmpty == false) &&
+                                 (self.tokenStore.getAccessToken()?.isEmpty == false)
+                    completion(hasAll)
+                }
+            }
+        }
+    }
+
+    private func refreshWithRetries(
+        maxRetries: Int,
+        delayMs: UInt64
+    ) async -> Bool {
+        var attempts = 0
+
+        while attempts < maxRetries {
+            let success: Bool = await withCheckedContinuation { cont in
+                self.handlePublisher(self.authService.refreshTokens()) { pair in
+                    self.tokenStore.manageTokenId(idToken: pair.idToken)
+                    self.tokenStore.manageAccessToken(accessToken: pair.accessToken)
+                    cont.resume(returning: true)
+                } onFailure: { _ in
+                    cont.resume(returning: false)
+                }
+            }
+
+            if success { return true }
+
+            attempts += 1
+            try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
+        }
+
+        return false
+    }
+
+    // MARK: - Helpers
+    private func isJWTExpired(_ token: String?, skew: TimeInterval) -> Bool {
+        guard let token, !token.isEmpty else { return true }
+        let parts = token.split(separator: ".")
+        guard parts.count == 3,
+              let payloadData = Data(base64URLEncoded: String(parts[1])),
+              let json = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+              let exp = json["exp"] as? TimeInterval else { return true }
+
+        let expiry = Date(timeIntervalSince1970: exp)
+        return expiry.addingTimeInterval(-skew) <= Date()
+    }
+
+    private func handlePublisher<T>(
+        _ publisher: AnyPublisher<T, AuthError>,
+        success: @escaping (T) -> Void,
+        onFailure: ((AuthError) -> Void)? = nil
+    ) {
+        publisher
+            .mapError { [weak self] error -> AuthError in
+                guard let self else { return .unknown }
+                if case let .awsError(awsError) = error { return self.errorMapper.map(awsError) }
+                return error
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] completion in
+                guard let self else { return }
+                if case .failure(let error) = completion {
+                    self.handleError(error)
+                    onFailure?(error)
+                }
+            } receiveValue: { value in
+                success(value)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func setSignedIn(user: String) {
+        isLoggedIn = true
+        authStateSubject.send(.session(user: user))
+        errorSubject.send(nil)
+        tokensReadySubject.send(false)
+    }
+}
+
+// MARK: - Base64URL util
 private extension Data {
     init?(base64URLEncoded: String) {
         var base = base64URLEncoded

--- a/Sources/AuthLibrarySPM/App/Service/AuthService.swift
+++ b/Sources/AuthLibrarySPM/App/Service/AuthService.swift
@@ -8,8 +8,11 @@
 import AWSMobileClientXCF
 import Combine
 
+private typealias AWSUserState = AWSMobileClientXCF.UserState
+private typealias AWSMCError  = AWSMobileClientXCF.AWSMobileClientError
+
 @available(iOS 13.0, *)
-public class AuthService: AuthServiceProtocol {
+public final class AuthService: AuthServiceProtocol {
 
     private let awsMobileClient: AWSMobileClient
 
@@ -17,24 +20,37 @@ public class AuthService: AuthServiceProtocol {
         self.awsMobileClient = awsmobileClient
     }
 
-    public func signUp(username: String, password: String, attributes: [String: String]) -> AnyPublisher<SignUpConfirmationState, AuthError> {
-        execute (
-            operation: { self.awsMobileClient.signUp(username: username, password: password, userAttributes: attributes, completionHandler: $0) },
-            transform: { $0.signUpConfirmationState }
+    // MARK: - Authentication lifecycle
+
+    public func signUp(
+        username: String,
+        password: String,
+        attributes: [String: String]
+    ) -> AnyPublisher<SignUpConfirmationState, AuthError> {
+        execute(
+            operation: { self.awsMobileClient.signUp(username: username,
+                                                     password: password,
+                                                     userAttributes: attributes,
+                                                     completionHandler: $0) },
+            transform: { $0?.signUpConfirmationState }
         )
     }
 
     public func confirmSignUp(username: String, confirmationCode: String) -> AnyPublisher<Void, AuthError> {
         execute(
-            operation: { self.awsMobileClient.confirmSignUp(username: username, confirmationCode: confirmationCode, completionHandler: $0) },
+            operation: { self.awsMobileClient.confirmSignUp(username: username,
+                                                            confirmationCode: confirmationCode,
+                                                            completionHandler: $0) },
             transform: { _ in () }
         )
     }
 
     public func signIn(username: String, password: String) -> AnyPublisher<SignInState, AuthError> {
         execute(
-            operation: { self.awsMobileClient.signIn(username: username, password: password, completionHandler: $0) },
-            transform: { $0.signInState }
+            operation: { self.awsMobileClient.signIn(username: username,
+                                                     password: password,
+                                                     completionHandler: $0) },
+            transform: { $0?.signInState }
         )
     }
 
@@ -45,66 +61,93 @@ public class AuthService: AuthServiceProtocol {
                     completion((), error)
                 }
             },
-            transform: { (_: Void) in () }
+            transform: { (_: Void?) in () }
         )
     }
 
+    // MARK: - Tokens
+
     public func getTokenId() -> AnyPublisher<String, AuthError> {
-        execute(operation: { self.awsMobileClient.getTokens($0) },
-                transform: { tokens in tokens?.idToken?.tokenString }
+        execute(
+            operation: { self.awsMobileClient.getTokens($0) },
+            transform: { tokens in tokens?.idToken?.tokenString }
         )
     }
 
     public func getRefreshToken() -> AnyPublisher<String, AuthError> {
-        execute(operation: { self.awsMobileClient.getTokens ($0) },
-                transform: { tokens in tokens?.refreshToken?.tokenString }
+        execute(
+            operation: { self.awsMobileClient.getTokens($0) },
+            transform: { tokens in tokens?.refreshToken?.tokenString }
         )
     }
 
     public func getAccessToken() -> AnyPublisher<String, AuthError> {
-        execute(operation: { self.awsMobileClient.getTokens($0) },
-                transform: { tokens in tokens?.accessToken?.tokenString }
+        execute(
+            operation: { self.awsMobileClient.getTokens($0) },
+            transform: { tokens in tokens?.accessToken?.tokenString }
         )
     }
-    
+
     public func refreshTokens() -> AnyPublisher<(idToken: String, accessToken: String), AuthError> {
-        return execute( operation: { completion in self.awsMobileClient.getTokens(completion) },
+        execute(
+            operation: { self.awsMobileClient.getTokens($0) },
             transform: { tokens in
-                guard let idToken = tokens.idToken?.tokenString,
-                      let accessToken = tokens.accessToken?.tokenString else {
-                    return nil
-                }
-                return (idToken: idToken, accessToken: accessToken)
+                guard
+                    let id = tokens?.idToken?.tokenString,
+                    let ac = tokens?.accessToken?.tokenString
+                else { return nil }
+                return (idToken: id, accessToken: ac)
             }
         )
     }
 
-    // MARK: Check user state in the Main App
+    // MARK: - Validation for user state
+
     public func checkUserState() -> AnyPublisher<UserState, AuthError> {
-        Future<UserState, AuthError> { promise in
-            let state = self.awsMobileClient.currentUserState
-            promise(.success(state))
+        Future<UserState, AuthError> { [weak self] promise in
+            guard let self else { return }
+            // currentUserState es del tipo top-level AWSMobileClientXCF.UserState
+            let awsState: AWSUserState = self.awsMobileClient.currentUserState
+            promise(.success(Self.mapAWSState(awsState)))
         }
         .eraseToAnyPublisher()
     }
 
+    // MARK: - Mapping
+
+    private static func mapAWSState(_ s: AWSUserState) -> UserState {
+        switch s {
+        case .signedIn:
+            return .signedIn
+        case .signedOut,
+             .signedOutUserPoolsTokenInvalid,
+             .signedOutFederatedTokensInvalid,
+             .guest,
+             .unknown:
+            return .signedOut
+        @unknown default:
+            return .signedOut
+        }
+    }
 }
+
+// MARK: - Helper (Publisher wrapper)
 
 @available(iOS 13.0, *)
 private func execute<T, R>(
     operation: @escaping (@escaping (R?, Error?) -> Void) -> Void,
-    transform: @escaping (R) -> T?
+    transform: @escaping (R?) -> T?
 ) -> AnyPublisher<T, AuthError> {
     Future<T, AuthError> { promise in
         operation { result, error in
-            if let error = error {
-                if let awsError = error as? AWSMobileClientError {
+            if let error {
+                if let awsError = error as? AWSMCError {
                     promise(.failure(.awsError(awsError)))
                 } else {
                     promise(.failure(.unknown))
                 }
-            } else if let result = result, let transformed = transform(result) {
-                promise(.success(transformed))
+            } else if let value = transform(result) {
+                promise(.success(value))
             } else {
                 promise(.failure(.unknown))
             }

--- a/Sources/AuthLibrarySPM/App/View/SignUpView.swift
+++ b/Sources/AuthLibrarySPM/App/View/SignUpView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 @available(iOS 14.0, *)
 public struct SignUpView: View {
-    let horizontalPadding : CGFloat = 15
-    @StateObject private var viewModel: SignUpViewModel
+    public let horizontalPadding: CGFloat = 15
+    @ObservedObject public var viewModel: SignUpViewModel
 
-    init(viewModel: SignUpViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+    public init(viewModel: SignUpViewModel) {
+        self._viewModel = ObservedObject(wrappedValue: viewModel)
     }
 
     public var body: some View {
@@ -22,44 +22,46 @@ public struct SignUpView: View {
             TextField(LocalizedStringKeys.GeneralEmailTextPlaceHolder, text: $viewModel.email)
                 .textFieldStyle()
                 .keyboardType(.emailAddress)
-            SecureInputField(title: LocalizedStringKeys.SignUpViewConfirmPasswordPlaceHolder, text: $viewModel.password)
-            SecureInputField(
-                title: LocalizedStringKeys.SignUpViewConfirmPasswordPlaceHolder,
-                text: $viewModel.confirmPassword
-            )
-            Button(LocalizedStringKeys.GeneralSignUpButton, action:{
+
+            SecureInputField(title: LocalizedStringKeys.SignUpViewConfirmPasswordPlaceHolder,
+                             text: $viewModel.password)
+
+            SecureInputField(title: LocalizedStringKeys.SignUpViewConfirmPasswordPlaceHolder,
+                             text: $viewModel.confirmPassword)
+
+            Button(LocalizedStringKeys.GeneralSignUpButton) {
                 viewModel.signUp()
-            })
+            }
             .buttonStyle(isEnabled: viewModel.requirementsFulfilled())
             .disabled(!viewModel.requirementsFulfilled())
 
-            if let firstRequirement = viewModel.signUpRequirements.first {
-                Text(firstRequirement.text)
+            if let first = viewModel.signUpRequirements.first {
+                Text(first.text)
                     .fontWeight(.bold)
-                    .foregroundColor(firstRequirement.isValid() ? .green : .red)
+                    .foregroundColor(first.isValid() ? .green : .red)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+
             VStack(alignment: .leading, spacing: 4) {
                 Text(LocalizedStringKeys.SignUpViewPasswordRequirementsLabel.localizedCapitalized)
                     .fontWeight(.bold)
-                ForEach(
-                    viewModel.signUpRequirements.dropFirst(),
-                    id: \.text
-                ) { requirement in
+
+                ForEach(viewModel.signUpRequirements.dropFirst(), id: \.text) { req in
                     HStack {
-                        Text(requirement.text)
-                            .foregroundColor(
-                                requirement.isValid() ? .green : .red
-                            )
+                        Text(req.text)
+                            .foregroundColor(req.isValid() ? .green : .red)
                     }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+
             viewModel.errorTextView
+
             Spacer()
-            Button(LocalizedStringKeys.SignUpViewAccountExistsPrompt.localizedCapitalized, action: {
+
+            Button(LocalizedStringKeys.SignUpViewAccountExistsPrompt.localizedCapitalized) {
                 viewModel.showLogin()
-            })
+            }
         }
         .padding()
         .padding(.horizontal, horizontalPadding)

--- a/Sources/AuthLibrarySPM/App/ViewModel/AuthViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/AuthViewModel.swift
@@ -9,62 +9,59 @@ import SwiftUI
 import Combine
 
 @available(iOS 13.0, *)
-public class AuthViewModel: ObservableObject {
-
+@MainActor
+public final class AuthViewModel: ObservableObject {
+    // MARK: Public properties
     @Published public var showError: Bool = false
     @Published public var authState: AuthState = .login
     @Published public var errorMessage: String? = nil
-
     public let authManager: AuthManager
 
+    // MARK: Private properties
     private var cancellables = Set<AnyCancellable>()
 
+    // MARK: Initializer
     public init(authManager: AuthManager) {
         self.authManager = authManager
         observeAuthManager()
     }
 
+    // MARK: Public methods
     public func clearErrorMessage() {
         authManager.clearErrorMessage()
         showError = false
     }
 
+    public func handleActionResult() {
+        showError = (errorMessage != nil)
+    }
+
+    public func showSignUp() { authManager.showSignUp() }
+    public func showLogin()  { authManager.showLogin()  }
+
+    @ViewBuilder
+    public var errorTextView: some View {
+        if let errorMessage {
+            Text(errorMessage).foregroundColor(.red)
+        } else {
+            EmptyView()
+        }
+    }
+
+    // MARK: Private properties
     private func observeAuthManager() {
         authManager.authStatePublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] authState in
-                self?.authState = authState
-            }
+            .sink { [weak self] s in self?.authState = s }
             .store(in: &cancellables)
 
         authManager.errorPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] error in
-                self?.errorMessage = error
-                self?.showError = error != nil
+            .sink { [weak self] e in
+                self?.errorMessage = e
+                self?.showError = (e != nil)
             }
             .store(in: &cancellables)
-    }
-
-    public func handleActionResult() {
-        showError = (self.errorMessage != nil)
-    }
-
-    open func showSignUp() {
-        authManager.showLogin()
-    }
-
-    open func showLogin() {
-        authManager.showLogin()
-    }
-
-    open var errorTextView: some View {
-        if let errorMessage = errorMessage {
-            return AnyView(Text(errorMessage)
-                .foregroundColor(.red))
-        } else {
-            return AnyView(EmptyView())
-        }
     }
 }
 

--- a/Sources/AuthLibrarySPM/App/ViewModel/ConfirmationViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/ConfirmationViewModel.swift
@@ -6,20 +6,61 @@
 //
 
 import SwiftUI
+import Combine
 
 @available(iOS 13.0, *)
 @MainActor
-public class ConfirmationViewModel: AuthViewModel {
+public final class ConfirmationViewModel: ObservableObject {
+    // MARK: Public properties
     @Published public var confirmationCode: String = ""
-    var username: String
+    @Published public var username: String
+    @Published public var showError: Bool = false
+    @Published public var errorMessage: String? = nil
+    @Published public var authState: AuthState = .login
+    public let authVM: AuthViewModel
+    public var authManager: AuthManager { authVM.authManager }
 
-    public init(authManager: AuthManager, username: String) {
+    // MARK: Private properties
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: Initializers
+    public init(authViewModel: AuthViewModel, username: String) {
+        self.authVM = authViewModel
         self.username = username
-        super.init(authManager: authManager)
+        bindAuthVM()
     }
+
+    public convenience init(authManager: AuthManager, username: String) {
+        self.init(authViewModel: AuthViewModel(authManager: authManager), username: username)
+    }
+
+    // MARK: - Public methods
 
     public func confirmSignUp() {
         authManager.confirmSignUp(username: username, confirmationCode: confirmationCode)
-        handleActionResult()
+    }
+
+    public func clearErrorMessage() { authVM.clearErrorMessage() }
+
+    @ViewBuilder
+    public var errorTextView: some View { authVM.errorTextView }
+
+    // MARK: - Private methods
+
+    private func bindAuthVM() {
+        authVM.$showError
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.showError = $0 }
+            .store(in: &cancellables)
+
+        authVM.$errorMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.errorMessage = $0 }
+            .store(in: &cancellables)
+
+        authVM.$authState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.authState = $0 }
+            .store(in: &cancellables)
     }
 }

--- a/Sources/AuthLibrarySPM/App/ViewModel/LoginViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/LoginViewModel.swift
@@ -5,155 +5,47 @@
 //  Created by Dionicio Cruz Velázquez on 2/5/25.
 //
 
-import Combine
 import SwiftUI
+import Combine
 
 @available(iOS 13.0, *)
 @MainActor
-public class LoginViewModel: AuthViewModel {
+public final class LoginViewModel: ObservableObject {
+    // MARK: Public properties
     @Published public var email: String = ""
     @Published public var password: String = ""
-    @Published private var isFaceIDInProgress = false
-    @Published public var isFaceIDEnabled: Bool { didSet { preferences.isFaceIDEnabled = isFaceIDEnabled } }
+    @Published public var isFaceIDEnabled: Bool = false
 
-    private let faceIDAuthenticator: FaceIDAuthenticator
-    private let keychain: KeychainProtocol
-    private var preferences: FaceIDPreferencesProtocol
-
+    // MARK: Private properties
+    private let authVM: AuthViewModel
+    private let authManager: AuthManager
     private var cancellables = Set<AnyCancellable>()
 
-    public init(
-        authManager: AuthManager,
-        keychain: KeychainProtocol = KeychainManager(),
-        preferences: FaceIDPreferencesProtocol,
-        faceIDAuthenticator: FaceIDAuthenticator = FaceIDAuthenticator()
-    ) {
-        self.keychain = keychain
-        self.preferences = preferences
-        self.faceIDAuthenticator = faceIDAuthenticator
-        self.isFaceIDEnabled = preferences.isFaceIDEnabled
-        super.init(authManager: authManager)
+    // MARK: Initializers
+    public init(authViewModel: AuthViewModel) {
+        self.authVM = authViewModel
+        self.authManager = authViewModel.authManager
+    }
 
-        loadCredentials()
+    // MARK: Public methods
+    public func clearErrorMessage() { authVM.clearErrorMessage() }
+    public func signUp()            { authVM.showSignUp() }
+    public var errorTextView: some View { authVM.errorTextView }
+
+    public func toggleFaceID(_ enabled: Bool) async {
+        self.isFaceIDEnabled = enabled
     }
 
     public func login() async {
-        if !email.isEmpty && !password.isEmpty {
-            manualLogin()
-        } else if FeatureFlags.shared.isBiometricLoginEnabled && isFaceIDEnabled {
-            await authenticateAndLogin()
-        } else {
-            errorMessage = LocalizedStringKeys.BiometricAuthenticatorErrorErrorEnterEmailPassword
+        let u = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let p = password
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            authManager.signIn(username: u, password: p)
+            cont.resume()
         }
     }
 
-    private func manualLogin() {
-        clearErrorMessage()
-        observeAuthEvents()
-        authManager.signIn(username: email, password: password)
-    }
-
-    public func tryAutoLogin() async {
-        guard preferences.isAppRelaunch, FeatureFlags.shared.isBiometricLoginEnabled, isFaceIDEnabled else { return }
-        preferences.isAppRelaunch = false
-        await authenticateAndLogin()
-    }
-
-    func authenticateAndLogin() async {
-        guard !isFaceIDInProgress else { return }
-        isFaceIDInProgress = true
-
-        do {
-            guard try await faceIDAuthenticator.authenticate() else { return }
-
-            guard let credentials = fetchStoredCredentials() else {
-                handleAuthenticationError(LocalizedStringKeys.BiometricAuthenticatorErrorCredentialsNotFound)
-                return
-            }
-
-            await login(with: credentials)
-        } catch {
-            handleAuthenticationError(error.localizedDescription)
-        }
-    }
-
-    private func fetchStoredCredentials() -> (email: String, password: String)? {
-        guard let email = keychain.get(key: "email"),
-              let password = keychain.get(key: "password"), !email.isEmpty, !password.isEmpty else { return nil }
-        return (email, password)
-    }
-
-    private func login(with credentials: (email: String, password: String)) async {
-        email = credentials.email
-        password = credentials.password
-        authManager.signIn(username: email, password: password)
-    }
-
-    public func toggleFaceID(_ enabled: Bool) async {
-        guard FeatureFlags.shared.isBiometricLoginEnabled else {
-                isFaceIDEnabled = false
-                return
-            }
-        guard enabled else {
-            isFaceIDEnabled = false
-            return
-        }
-
-        do {
-            guard try await faceIDAuthenticator.authenticate() else {
-                isFaceIDEnabled = false
-                return
-            }
-            isFaceIDEnabled = true
-            preferences.hasLoggedOut = false
-            await tryAutoLogin()
-        } catch let error as FaceIdError {
-            errorMessage = error.localizedDescription
-            isFaceIDEnabled = false
-        } catch {
-            errorMessage = LocalizedStringKeys.BiometricAuthenticatorErrorFaceIdPermissionDenied
-            isFaceIDEnabled = false
-        }
-    }
-
-    public func signUp() {
-        authManager.showSignUp()
-    }
-
-    public func loadCredentials() {
-        email = keychain.get(key: CredentialsKeys.email.rawValue) ?? ""
-    }
-
-    private func saveCredentials() {
-        keychain.set(email, key: CredentialsKeys.email.rawValue)
-        keychain.set(password, key: CredentialsKeys.password.rawValue)
-    }
-
-    override public func clearErrorMessage() {
-        super.clearErrorMessage()
-    }
-    
-    private func handleAuthenticationError(_ message: String) {
-            self.errorMessage = message
-            self.isFaceIDInProgress = false
-    }
-
-    private func observeAuthEvents() {
-        authManager.errorPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] error in
-                guard let error else { return }
-                self?.errorMessage = error
-            }
-            .store(in: &cancellables)
-
-        authManager.authStatePublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                if case .session = state {
-                    self?.saveCredentials()
-                }
-            }
-            .store(in: &cancellables)
+    public func tryAutoLogin() {
+        // TODO: Implement logic
     }
 }

--- a/Sources/AuthLibrarySPM/App/ViewModel/SessionViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/SessionViewModel.swift
@@ -6,17 +6,66 @@
 //
 
 import SwiftUI
+import Combine
 
 @available(iOS 13.0, *)
-public class SessionViewModel: AuthViewModel {
+@MainActor
+public final class SessionViewModel: ObservableObject {
+    // MARK: Public properties
     @Published public var user: String
+    @Published public var showError: Bool = false
+    @Published public var errorMessage: String? = nil
+    @Published public var authState: AuthState = .login
+    public let authVM: AuthViewModel
+    public var authManager: AuthManager { authVM.authManager }
 
-    public init(authManager: AuthManager, user: String) {
+    // MARK: Private properties
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: Initializer
+    public init(authViewModel: AuthViewModel, user: String) {
+        self.authVM = authViewModel
         self.user = user
-        super.init(authManager: authManager)
+        bindAuthVM()
     }
+
+    public convenience init(authManager: AuthManager, user: String) {
+        let authVM = AuthViewModel(authManager: authManager)
+        self.init(authViewModel: authVM, user: user)
+    }
+
+    // MARK: - Public methods
 
     public func logout() {
         authManager.signOut()
     }
+
+    public func clearErrorMessage() {
+        authVM.clearErrorMessage()
+    }
+
+    @ViewBuilder
+    public var errorTextView: some View {
+        authVM.errorTextView
+    }
+
+    // MARK: - Private methods
+
+    private func bindAuthVM() {
+        authVM.$showError
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.showError = $0 }
+            .store(in: &cancellables)
+
+        authVM.$errorMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.errorMessage = $0 }
+            .store(in: &cancellables)
+
+        authVM.$authState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.authState = $0 }
+            .store(in: &cancellables)
+    }
 }
+

--- a/Sources/AuthLibrarySPM/App/ViewModel/SettingsViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/SettingsViewModel.swift
@@ -5,22 +5,71 @@
 //  Created by Dionicio Cruz Velázquez on 3/10/25.
 //
 
-import Combine
 import SwiftUI
+import Combine
 
 @available(iOS 14.0, *)
 @MainActor
-public class SettingsViewModel: AuthViewModel {
+public final class SettingsViewModel: ObservableObject {
+    // MARK: Public properties
+    @Published public var showError: Bool = false
+    @Published public var errorMessage: String? = nil
+    @Published public var authState: AuthState = .login
+    public var preferences: FaceIDPreferencesProtocol
+    public let authVM: AuthViewModel
+    public var authManager: AuthManager { authVM.authManager }
 
-    var preferences: FaceIDPreferencesProtocol
-    
-    public init(authManager: AuthManager, preferences: FaceIDPreferencesProtocol = FaceIDPreferencesManager()) {
+    // MARK: Private properties
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: Initializer
+    public init(
+        authViewModel: AuthViewModel,
+        preferences: FaceIDPreferencesProtocol = FaceIDPreferencesManager()
+    ) {
+        self.authVM = authViewModel
         self.preferences = preferences
-        super.init(authManager: authManager)
+        bindAuthVM()
     }
 
+    public convenience init(
+        authManager: AuthManager,
+        preferences: FaceIDPreferencesProtocol = FaceIDPreferencesManager()
+    ) {
+        self.init(authViewModel: AuthViewModel(authManager: authManager), preferences: preferences)
+    }
+
+    // MARK: - Public methods
     public func signOut() {
         authManager.signOut()
         preferences.hasLoggedOut = true
+    }
+
+    public func clearErrorMessage() {
+        authVM.clearErrorMessage()
+    }
+
+    @ViewBuilder
+    public var errorTextView: some View {
+        authVM.errorTextView
+    }
+
+    // MARK: - Private methods
+
+    private func bindAuthVM() {
+        authVM.$showError
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.showError = $0 }
+            .store(in: &cancellables)
+
+        authVM.$errorMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.errorMessage = $0 }
+            .store(in: &cancellables)
+
+        authVM.$authState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.authState = $0 }
+            .store(in: &cancellables)
     }
 }

--- a/Sources/AuthLibrarySPM/App/ViewModel/SingUpViewModel.swift
+++ b/Sources/AuthLibrarySPM/App/ViewModel/SingUpViewModel.swift
@@ -6,14 +6,32 @@
 //
 
 import SwiftUI
+import Combine
 
 @available(iOS 13.0, *)
-public class SignUpViewModel: AuthViewModel {
+@MainActor
+public final class SignUpViewModel: ObservableObject {
+    // MARK: Public properties
     @Published public var email: String = ""
     @Published public var password: String = ""
     @Published public var confirmPassword: String = ""
     @Published public var showConfirmationCodeView: Bool = false
+    public let authVM: AuthViewModel
+    public var authManager: AuthManager { authVM.authManager }
 
+    // MARK: Private properties
+    private let keychain = KeychainManager()
+
+    // MARK: Initializer
+    public init(authViewModel: AuthViewModel) {
+        self.authVM = authViewModel
+    }
+
+    public convenience init(authManager: AuthManager) {
+        self.init(authViewModel: AuthViewModel(authManager: authManager))
+    }
+
+    // MARK: Validations
     var signUpRequirements: [SignUpRequirements] {
         [
             SignUpRequirements(text: LocalizedStringKeys.SignUpRequirementValidEmail) {
@@ -40,34 +58,38 @@ public class SignUpViewModel: AuthViewModel {
         ]
     }
 
-    private let keychain = KeychainManager()
+    // MARK: - Public methods
 
-    override public init(authManager: AuthManager) {
-        super.init(authManager: authManager)
-    }
+    public func clearErrorMessage() {
+          authVM.clearErrorMessage()
+      }
 
     public func signUp() {
-        guard !email.isEmpty, !password.isEmpty, password == confirmPassword else {
-            self.errorMessage = LocalizedStringKeys.SignUpRequirementInvalidEmailAndPassword
-            handleActionResult()
+        guard requirementsFulfilled() else {
+            authVM.errorMessage = LocalizedStringKeys.SignUpRequirementInvalidEmailAndPassword
+            authVM.handleActionResult()
             return
         }
 
         keychain.set(password, key: CredentialsKeys.password.rawValue)
-        keychain.set(email, key: CredentialsKeys.email.rawValue)
+        keychain.set(email,   key: CredentialsKeys.email.rawValue)
 
         let attributes = ["email": email, "name": email]
         authManager.signUp(username: email, password: password, attributes: attributes)
-        handleActionResult()
 
-        if self.errorMessage == nil {
+        authVM.handleActionResult()
+
+        if authVM.errorMessage == nil {
             showConfirmationCodeView = true
         }
     }
 
-    public override func showLogin() {
-        super.showLogin()
+    public func showLogin() {
+        authVM.showLogin()
     }
+
+    @ViewBuilder
+    public var errorTextView: some View { authVM.errorTextView }
 
     public func requirementsFulfilled() -> Bool {
         signUpRequirements.allSatisfy { $0.isValid() }

--- a/Sources/AuthLibrarySPM/AuthApp.swift
+++ b/Sources/AuthLibrarySPM/AuthApp.swift
@@ -1,40 +1,53 @@
-import AWSMobileClientXCF
+
 import SwiftUI
 
 @available(iOS 17.0, *)
 public struct AuthApp<SessionViewType: View, LoginViewType: View>: View {
 
+    // MARK: Private properties
     @ObservedObject private var authManager: AuthManager
     @ObservedObject private var authViewModel: AuthViewModel
     @StateObject private var appLifecycleObserver = AppLifecycleObserver()
+
     private let sessionViewProvider: (String) -> SessionViewType
     private let loginViewProvider: (LoginViewModel) -> LoginViewType
 
+    // MARK: - Initializer
     public init(
         authManager: AuthManager,
-        authviewModel: AuthViewModel,
-        @ViewBuilder loginView: @escaping (LoginViewModel) -> LoginViewType = { viewModel in  LoginView(viewModel: viewModel)},
+        authViewModel: AuthViewModel,
+        @ViewBuilder loginView: @escaping (LoginViewModel) -> LoginViewType = { vm in
+            LoginView(viewModel: vm)
+        },
         @ViewBuilder sessionView: @escaping (String) -> SessionViewType
     ) {
         self.authManager = authManager
-        self.authViewModel = authviewModel
+        self.authViewModel = authViewModel
         self.sessionViewProvider = sessionView
         self.loginViewProvider = loginView
     }
 
+    // MARK: - Body builder
     public var body: some View {
         VStack {
             switch authViewModel.authState {
+
             case .login:
-                let viewModel = LoginViewModel(authManager: authManager, preferences: FaceIDPreferencesManager())
-                loginViewProvider(viewModel)
+                let vm = LoginViewModel(authViewModel: authViewModel)
+                loginViewProvider(vm)
+
             case .signUp:
-                SignUpView(viewModel: SignUpViewModel(authManager: authManager))
+                let vm = SignUpViewModel(authViewModel: authViewModel)
+                SignUpView(viewModel: vm)
+
             case .confirmCode(let username):
-                ConfirmationView(viewModel: ConfirmationViewModel(authManager: authManager, username: username))
+                let vm = ConfirmationViewModel(authViewModel: authViewModel, username: username)
+                ConfirmationView(viewModel: vm)
+
             case .session(let user):
                 sessionViewProvider(user)
             }
         }
     }
 }
+


### PR DESCRIPTION
# Description

The auth library was refactor in order to have a more sorted way to handle authentication and a cleaner way to use the authentication states in the parent library.

The auth manager was almost completely changed to improve the authentication logic.

Session view needs to be removed, is no longer needed.